### PR TITLE
maint: add dependabot to project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@
 
 version: 2
 updates:
-  # root directory
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
@@ -14,12 +13,3 @@ updates:
       - "type: dependencies"
     reviewers:
       - "honeycombio/telemetry-team"
-  # opentelemetry-node
-  - package-ecosystem: "npm"
-    directory: "/packages/opentelemetry-node"
-    schedule:
-        interval: "monthly"
-    labels:
-        - "type: dependencies"
-    reviewers:
-        - "honeycombio/telemetry-team"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #9 

## Short description of the changes

- add dependabot for root-level `package.json` and opentelemetry-node `package.json`

## How to verify that this has the expected result

- new dependabots should open for old dependencies on both/either directory, labeled as "type: dependencies"