### PR TITLE
Update CircleCI to publish to Github & NPM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,16 +66,9 @@ jobs:
   publish_github:
     executor: github
     steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: "Artifacts being published"
-          command: |
-            echo "about to publish to tag ${CIRCLE_TAG}"
-            ls -l ~/artifacts/*
       - run:
           name: "GHR Draft"
-          command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+          command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG}
 
   publish_npm:
     executor: node


### PR DESCRIPTION
## Which problem is this PR solving?
Adds jobs to the CircleCI workflow to publish to NPM and create a draft Github release.

- Closes #8

## Short description of the changes
- Add reusable filter blocks for always and publish
- Add executors to manage the node and github docker images used in jobs
- Add NPM and github publish steps
- Wire up existing and new jobs to execute using the new filter blocks

## How to verify that this has the expected result
- PRs should continue to lint, check format and build but not publish
- When a tag is created and pushed, two additional workflow steps are executed to publish to NPM and github.