### PR TITLE
Make version in package.json into a usable string

### DIFF
--- a/src/resource-builder.ts
+++ b/src/resource-builder.ts
@@ -2,16 +2,14 @@ import { Resource, ResourceAttributes } from '@opentelemetry/resources';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { getEnv } from '@opentelemetry/core';
 import { HoneycombOptions } from './honeycomb-options';
-
-// TODO: generate as part of the build process from package.json
-export const version = '0.1.0';
+import { VERSION } from './version';
 
 export function addResource(options?: HoneycombOptions): Resource {
   // get OTel environemt which includes common properties like service name
   const env = getEnv();
 
   const resourceAttrs: ResourceAttributes = {
-    'honeycomb.distro.version': version,
+    'honeycomb.distro.version': VERSION,
     'honeycomb.distro.runtime_version': process.versions.node,
   };
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,3 @@
+import { version } from '../package.json';
+
+export const VERSION = version;

--- a/test/resource-builder.test.ts
+++ b/test/resource-builder.test.ts
@@ -1,11 +1,12 @@
-import { addResource, version } from '../src/resource-builder';
+import { addResource } from '../src/resource-builder';
 import { Resource } from '@opentelemetry/resources';
 import { HoneycombOptions } from '../src/honeycomb-options';
+import { VERSION } from '../src/version';
 
 test('it should return a Resource', () => {
   const resource = addResource();
   expect(resource instanceof Resource);
-  expect(resource.attributes['honeycomb.distro.version']).toEqual(version);
+  expect(resource.attributes['honeycomb.distro.version']).toEqual(VERSION);
   expect(resource.attributes['honeycomb.distro.runtime_version']).toEqual(
     process.versions.node,
   );
@@ -19,7 +20,7 @@ test('it should use options service name when set', () => {
   };
   const resource = addResource(options);
   expect(resource instanceof Resource);
-  expect(resource.attributes['honeycomb.distro.version']).toEqual(version);
+  expect(resource.attributes['honeycomb.distro.version']).toEqual(VERSION);
   expect(resource.attributes['honeycomb.distro.runtime_version']).toEqual(
     process.versions.node,
   );
@@ -42,7 +43,7 @@ describe('when OTEL_SERVICE_NAME env var is set', () => {
     };
     const resource = addResource(options);
     expect(resource instanceof Resource);
-    expect(resource.attributes['honeycomb.distro.version']).toEqual(version);
+    expect(resource.attributes['honeycomb.distro.version']).toEqual(VERSION);
     expect(resource.attributes['honeycomb.distro.runtime_version']).toEqual(
       process.versions.node,
     );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,7 +36,7 @@
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    "resolveJsonModule": true,                           /* Enable importing .json files. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
     /* JavaScript Support */


### PR DESCRIPTION
## Which problem is this PR solving?
Makes the package version in package.json usable by typescript files so we don't need to maintain it in both places.

- Closes #66 

## Short description of the changes
- Updates tsconfig to allow importing json files
- Add version.ts that imports package.json and make it a const
- Update usage of version to new variable

## How to verify that this has the expected result
The version in package.json is used when setting the honeycomb resource.