### PR TITLE
wip add interface option for instrumentations

### DIFF
--- a/src/honeycomb-options.ts
+++ b/src/honeycomb-options.ts
@@ -1,3 +1,4 @@
+import { InstrumentationOption } from '@opentelemetry/instrumentation';
 export const DEFAULT_API_ENDPOINT = 'https://api.honeycomb.io';
 export const DEFAULT_SAMPLE_RATE = 1;
 export const DEFAULT_OTLP_EXPORTER_PROTOCOL = 'http/protobuf';
@@ -47,6 +48,9 @@ export interface HoneycombOptions {
 
   /** The local visualizations flag enables logging Honeycomb URLs for completed traces. Do not use in production. */
   localVisualizations?: boolean;
+
+  /** The instrumentations to be included. Defaults to none enabled. */
+  instrumentations?: InstrumentationOption[];
 }
 
 /**
@@ -81,6 +85,7 @@ export function computeOptions(options?: HoneycombOptions): HoneycombOptions {
     metricsDataset: env.HONEYCOMB_METRICS_DATASET || options?.metricsDataset,
     sampleRate: getSampleRate(env, options),
     debug: env.DEBUG || options?.debug || false,
+    instrumentations: options?.instrumentations,
     localVisualizations:
       env.HONEYCOMB_ENABLE_LOCAL_VISUALIZATIONS ||
       options?.localVisualizations ||

--- a/src/instrumentations.ts
+++ b/src/instrumentations.ts
@@ -1,0 +1,18 @@
+import { computeOptions, HoneycombOptions } from './honeycomb-options';
+import { InstrumentationOption } from '@opentelemetry/instrumentation';
+
+/**
+ * Builds and returns an Opentelemetry Instrumentation Option
+ * @param options The {@link HoneycombOptions} used to configure the instrumentations
+ * @returns an InstrumentationOption, with default of no instrumentations included
+ */
+export function configureInstrumentations(
+  options: HoneycombOptions,
+): InstrumentationOption[] {
+  let instr: InstrumentationOption[] = [];
+  const opts = computeOptions(options);
+  if (opts?.instrumentations) {
+    instr = opts?.instrumentations;
+  }
+  return instr;
+}

--- a/src/opentelemetry-node.ts
+++ b/src/opentelemetry-node.ts
@@ -3,6 +3,7 @@ import { configureDeterministicSampler } from './deterministic-sampler';
 import { configureBatchWithBaggageSpanProcessor } from './baggage-span-processor';
 import { computeOptions, HoneycombOptions } from './honeycomb-options';
 import { configureHoneycombResource } from './resource-builder';
+import { configureInstrumentations } from './instrumentations';
 import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
 /**
  * Builds and returns an instance of OpenTelemetry Node SDK.
@@ -23,5 +24,6 @@ export function configureHoneycombSDK(options?: HoneycombOptions): NodeSDK {
     // metricReader: honeycombMetricsReader(options),
     spanProcessor: configureBatchWithBaggageSpanProcessor(opts),
     sampler: configureDeterministicSampler(opts.sampleRate),
+    instrumentations: configureInstrumentations(opts),
   });
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #92 

## Short description of the changes

## How to verify that this has the expected result

```js
const {
  getNodeAutoInstrumentations,
} = require('@opentelemetry/auto-instrumentations-node');

const sdk = configureHoneycombSDK({
  instrumentations: [getNodeAutoInstrumentations()],
});
```