### PR TITLE
maint: use more reliable jest method in tests

### DIFF
--- a/test/deterministic-sampler.test.ts
+++ b/test/deterministic-sampler.test.ts
@@ -29,7 +29,7 @@ const getSamplingResult = (sampler: DeterministicSampler): SamplingResult => {
 
 it('sampler with rate of undefined configures inner AlwaysOnSampler', () => {
   const sampler = configureDeterministicSampler();
-  expect(sampler instanceof DeterministicSampler);
+  expect(sampler).toBeInstanceOf(DeterministicSampler);
   expect(sampler.toString()).toBe('DeterministicSampler(AlwaysOnSampler)');
 
   const result = getSamplingResult(sampler);
@@ -39,7 +39,7 @@ it('sampler with rate of undefined configures inner AlwaysOnSampler', () => {
 
 it('sampler with rate of 1 configures inner AlwaysOnSampler', () => {
   const sampler = configureDeterministicSampler(1);
-  expect(sampler instanceof DeterministicSampler);
+  expect(sampler).toBeInstanceOf(DeterministicSampler);
   expect(sampler.toString()).toBe('DeterministicSampler(AlwaysOnSampler)');
 
   const result = getSamplingResult(sampler);
@@ -49,7 +49,7 @@ it('sampler with rate of 1 configures inner AlwaysOnSampler', () => {
 
 it('sampler with rate of 0 configures inner AlwaysOffSampler', () => {
   const sampler = configureDeterministicSampler(0);
-  expect(sampler instanceof DeterministicSampler);
+  expect(sampler).toBeInstanceOf(DeterministicSampler);
   expect(sampler.toString()).toBe('DeterministicSampler(AlwaysOffSampler)');
 
   const result = getSamplingResult(sampler);
@@ -59,7 +59,7 @@ it('sampler with rate of 0 configures inner AlwaysOffSampler', () => {
 
 it('sampler with rate of 10 configures inner TraceIdRatioBased sampler with a ratio of 0.1', () => {
   const sampler = new DeterministicSampler(10);
-  expect(sampler instanceof DeterministicSampler);
+  expect(sampler).toBeInstanceOf(DeterministicSampler);
   expect(sampler.toString()).toBe(
     'DeterministicSampler(TraceIdRatioBased{0.1})',
   );

--- a/test/exporter-utils.test.ts
+++ b/test/exporter-utils.test.ts
@@ -14,18 +14,18 @@ describe('getHoneycombSpanExporter', () => {
     const exporter = getHoneycombSpanExporter({
       protocol: 'grpc',
     });
-    expect(exporter instanceof GrpcOTLPTraceExporter);
+    expect(exporter).toBeInstanceOf(GrpcOTLPTraceExporter);
   });
   it('http/protobuf return http/proto exporter', () => {
     const exporter = getHoneycombSpanExporter({
       protocol: 'http/protobuf',
     });
-    expect(exporter instanceof HttpProtoOTLPExporter);
+    expect(exporter).toBeInstanceOf(HttpProtoOTLPExporter);
   });
   it('http/json return http/proto exporter', () => {
     const exporter = getHoneycombSpanExporter({
       protocol: 'http/json',
     });
-    expect(exporter instanceof HttpProtoOTLPExporter);
+    expect(exporter).toBeInstanceOf(HttpProtoOTLPExporter);
   });
 });

--- a/test/grpc-trace-exporter.test.ts
+++ b/test/grpc-trace-exporter.test.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
 
 test('it should return an OTLPTraceExporter', () => {
   const traceExporter = configureHoneycombGrpcTraceExporter();
-  expect(traceExporter instanceof OTLPTraceExporter);
+  expect(traceExporter).toBeInstanceOf(OTLPTraceExporter);
 });
 
 describe('with a regular apikey', () => {

--- a/test/http-proto-trace-exporter.test.ts
+++ b/test/http-proto-trace-exporter.test.ts
@@ -14,7 +14,7 @@ const classicApikey = '00000000000000000000000000000000'; // 32 chars
 
 test('it should return an OTLPTraceExporter', () => {
   const traceExporter = configureHoneycombHttpProtoTraceExporter();
-  expect(traceExporter instanceof OTLPTraceExporter);
+  expect(traceExporter).toBeInstanceOf(OTLPTraceExporter);
 });
 
 describe('with a regular apikey', () => {

--- a/test/resource-builder.test.ts
+++ b/test/resource-builder.test.ts
@@ -4,7 +4,7 @@ import { VERSION } from '../src/version';
 
 test('it should return a Resource', () => {
   const resource = configureHoneycombResource();
-  expect(resource instanceof Resource);
+  expect(resource).toBeInstanceOf(Resource);
   expect(resource.attributes['honeycomb.distro.version']).toEqual(VERSION);
   expect(resource.attributes['honeycomb.distro.runtime_version']).toEqual(
     process.versions.node,


### PR DESCRIPTION
## Which problem is this PR solving?

While writing new tests, realized `instanceof` was not failing when it should have. This means the tests were not reliable.

## Short description of the changes

- replace `instanceof` to `toBeInstanceOf` in tests to [check that an object is an instance of a class](https://jestjs.io/docs/expect#tobeinstanceofclass). `toBeInstanceOf` is more reliable and uses `instanceof` under the hood... not totally sure of why `instanceof` was passing when it should not have been, but this way seems to be the most current way to test class members anyway.

## How to verify that this has the expected result

In `index.test.ts`:

```js
test('it should return a NodeSDK', () => {
  const honeycomb = new HoneycombSDK();
  expect(honeycomb).toBeInstanceOf(NodeSDK);
  expect(honeycomb).toBeInstanceOf(String);
  expect(honeycomb instanceof NodeSDK);
  expect(honeycomb instanceof String);
});
```

`npm run test index.test.ts` only shows a single fail

```sh
 FAIL  test/index.test.ts
  ● it should return a NodeSDK

    expect(received).toBeInstanceOf(expected)

    Expected constructor: String
    Received constructor: HoneycombSDK

      12 |   const honeycomb = new HoneycombSDK();
      13 |   expect(honeycomb).toBeInstanceOf(NodeSDK);
    > 14 |   expect(honeycomb).toBeInstanceOf(String);
         |                     ^
      15 |   expect(honeycomb instanceof NodeSDK);
      16 |   expect(honeycomb instanceof String);
      17 | });

      at Object.<anonymous> (test/index.test.ts:14:21)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        2.656 s
```