### PR TITLE
ci: add validate pr title workflow

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,37 @@
+name: "Validate PR Title"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+  # Using `pull_request_target` so that PRs from forked repos are validated
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Have to specify all types because `maint` and `rel` aren't defaults
+          types: |
+            maint
+            rel
+            fix
+            feat
+            chore
+            ci
+            docs
+            style
+            refactor
+            perf
+            test


### PR DESCRIPTION
## Which problem is this PR solving?
Adds a  GitHub action that validates that PR titles for this repo follow the [conventional commit](https://www.conventionalcommits.org) pattern. This helps us make releases a lot easier.

- Closes #101 

## Short description of the changes
- Added `validate-pr-title.yml` to the `.github/workflows` folder. This workflow uses the [semantic-pull-request](https://github.com/marketplace/actions/semantic-pull-request) to check whether PR titles follow the conventional commit pattern. I chose this action since it is much more widely used than other open source actions and there's support for supplying your own custom prefixes which we needed for `maint:` and `rel:`.

## How to verify that this has the expected result
### Tests I did
- [x] Opened this PR without an approved prefix in the title and the action [failed](https://github.com/honeycombio/honeycomb-opentelemetry-node/actions/runs/3482974946/jobs/5825921999)
- [x] Added the `ci:` prefix to the title and the action reran and [passed](https://github.com/honeycombio/honeycomb-opentelemetry-node/actions/runs/3482980116/jobs/5825933267)

To play around with this, change the PR title and it should trigger the action to run.
