### PR TITLE
ci: update publish setup command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run: npm ci
       - run: npm run build
-      - run: npm publish
+      - run: npm publish --access public
 
 workflows:
   nightly:

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -6,12 +6,6 @@ on:
       - opened
       - edited
       - synchronize
-  # Using `pull_request_target` so that PRs from forked repos are validated
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
 
 jobs:
   main:


### PR DESCRIPTION
## Which problem is this PR solving?
The publish command requires `--access public` to be specified if a package is being published as a scoped package

## Short description of the changes
- Updated the publish command
- Removed `pull_request_target` from the validate PR title check

## How to verify that this has the expected result
- We have a [published package](https://www.npmjs.com/package/@honeycombio/opentelemetry-node)! 
