### PR TITLE
test: add smoky expectations for BaggageSpanProcessor

### DIFF
--- a/smoke-tests/smoke-sdk-grpc.bats
+++ b/smoke-tests/smoke-sdk-grpc.bats
@@ -43,3 +43,8 @@ teardown_file() {
 	result=$(span_attributes_for ${TRACER_NAME} | jq "select(.key == \"delay_ms\").value.intValue")
 	assert_equal "$result" '"100"'
 }
+
+@test "BaggageSpanProcessor: key-values added to baggage appear on child spans" {
+	result=$(span_attributes_for ${TRACER_NAME} | jq "select(.key == \"for_the_children\").value.stringValue")
+	assert_equal "$result" '"another important value"'
+}

--- a/smoke-tests/smoke-sdk-http.bats
+++ b/smoke-tests/smoke-sdk-http.bats
@@ -43,3 +43,8 @@ teardown_file() {
 	result=$(span_attributes_for ${TRACER_NAME} | jq "select(.key == \"delay_ms\").value.intValue")
 	assert_equal "$result" '"100"'
 }
+
+@test "BaggageSpanProcessor: key-values added to baggage appear on child spans" {
+	result=$(span_attributes_for ${TRACER_NAME} | jq "select(.key == \"for_the_children\").value.stringValue")
+	assert_equal "$result" '"another important value"'
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #105 

## Short description of the changes

- Adds usage of baggage to hello-world-express example app.
- Adds smoke test expectations that key/values in baggage appear on child spans from within that context.

## How to verify that this has the expected result

- Run the smoke tests!
