### PR TITLE
maint: update opentelemetry dependencies

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -55,6 +55,10 @@ Testing scripts
 
 To run the example from the root directory, run `npm run example-node`.
 
+- [Hello World Express](./examples/hello-node-express/) is a simple javascript application that uses Express.
+
+To run the example from the root directory, run `npm run example-node-express`.
+
 ## Building a Tarball for Local Development
 
 To get a tarball to use as a local dependency, after cleaning and building run `npm pack`:

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -55,6 +55,30 @@ Testing scripts
 
 To run the example from the root directory, run `npm run example-node`.
 
+## Building a Tarball for Local Development
+
+To get a tarball to use as a local dependency, after cleaning and building run `npm pack`:
+
+```sh
+npm install
+npm run clean
+npm run build
+npm pack
+```
+
+This creates a file in the root directory like this: `honeycombio-opentelemetry-node-0.1.42-beta.tgz`
+To use as a dependency in another project, install it with `npm`:
+
+`npm install honeycombio-opentelemetry-node-0.1.1-beta.tgz`
+
+This will create a dependency in your `package.json` like this:
+
+```json
+  "dependencies": {
+    "@honeycombio/opentelemetry-node": "file:honeycombio-opentelemetry-node-0.1.42-beta.tgz",
+  }
+```
+
 ## Make is Cool
 
 This is one of several projects maintained by the same group of people.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@honeycombio/opentelemetry-node",
-  "version": "0.1.1-beta",
+  "version": "0.1.42-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@honeycombio/opentelemetry-node",
-      "version": "0.1.1-beta",
+      "version": "0.1.42-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.3",
-        "@opentelemetry/api": "^1.2.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "^0.33.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.33.0",
-        "@opentelemetry/resources": "^1.7.0",
-        "@opentelemetry/sdk-node": "^0.33.0",
-        "@opentelemetry/sdk-trace-base": "^1.7.0",
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.34.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.34.0",
+        "@opentelemetry/resources": "^1.8.0",
+        "@opentelemetry/sdk-node": "^0.34.0",
+        "@opentelemetry/sdk-trace-base": "^1.8.0",
         "axios": "^1.1.3"
       },
       "devDependencies": {
@@ -676,7 +676,7 @@
         "node": "^8.13.0 || >=10.10.0"
       }
     },
-    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+    "node_modules/@grpc/proto-loader": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.3.tgz",
       "integrity": "sha512-5dAvoZwna2Py3Ef96Ux9jIkp3iZ62TUsV00p3wVBPNX5K178UbNi8Q7gQVqwXT1Yq9RejIGG9G2IPEo93T6RcA==",
@@ -685,52 +685,6 @@
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
         "protobufjs": "^7.0.0",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@grpc/grpc-js/node_modules/protobufjs": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
-      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@grpc/grpc-js/node_modules/protobufjs/node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-    },
-    "node_modules/@grpc/proto-loader": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
-      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
-      "dependencies": {
-        "@types/long": "^4.0.1",
-        "lodash.camelcase": "^4.3.0",
-        "long": "^4.0.0",
-        "protobufjs": "^6.11.3",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -1242,61 +1196,84 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.2.0.tgz",
-      "integrity": "sha512-0nBr+VZNKm9tvNDZFstI3Pq1fCTEDK5OZTnVKNvBNAKgd0yIvmwsP4m61rEv7ZP+tOUjWJhROpxK5MsnlF911g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
+      "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@opentelemetry/api-metrics": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz",
-      "integrity": "sha512-78evfPRRRnJA6uZ3xuBuS3VZlXTO/LRs+Ff1iv3O/7DgibCtq9k27T6Zlj8yRdJDFmcjcbQrvC0/CpDpWHaZYA==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.7.0.tgz",
-      "integrity": "sha512-g4bMzyVW5dVBeMkyadaf3NRFpmNrdD4Pp9OJsrP29HwIam/zVMNfIWQpT5IBzjtTSMhl/ED5YQYR+UOSjVq3sQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.8.0.tgz",
+      "integrity": "sha512-ueLmocbWDi1aoU4IPdOQyt4qz/Dx+NYyU4qoa3d683usbnkDLUXYXJFfKIMPFV2BbrI5qtnpTtzErCKewoM8aw==",
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
-      "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-6SDjwBML4Am0AQmy7z1j6HGrWDgeK8awBRUvl1PGw6HayViMk4QpnUXvv4HTHisecgVBy43NE/cstWprm8tIfw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/semantic-conventions": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-jaeger": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.8.0.tgz",
+      "integrity": "sha512-3h16Sb1T/G33S+RM3yjt1t2xRuu/mi9iB172faS6qFQEclTTJru1pTK4wuWG+9GyI7uyBLfbQoXVA5/BA6gvHw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0",
+        "jaeger-client": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.33.0.tgz",
-      "integrity": "sha512-B+XGvNE5RcMlXkA8F9fdvr7hZ3Bvi1OGIW8iNicQ508A5OTpTrOHTXfkYdCjwPpAaZTGoxKJmAF2dwaAw76fmg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.34.0.tgz",
+      "integrity": "sha512-x1V0daRLS6k0dhBPNNLMOP+OSrh8M60Xs9/YkuZS0+/zdbcIjNvPzo/8+dK3zOJx+j1KF0oBX9zxK0SX3PSnZw==",
       "dependencies": {
-        "@grpc/grpc-js": "^1.5.9",
-        "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.33.0",
-        "@opentelemetry/otlp-transformer": "0.33.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/sdk-trace-base": "1.7.0"
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.34.0",
+        "@opentelemetry/otlp-transformer": "0.34.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.34.0.tgz",
+      "integrity": "sha512-MBtUwMvgpdoRo9iqK2eDJ8SP2xKYWeBCSu99s4cc1kg4HKKOpenXLE/6daGsSZ+QTPwd8j+9xMSd+hhBg+Bvzw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/otlp-exporter-base": "0.34.0",
+        "@opentelemetry/otlp-transformer": "0.34.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0"
       },
       "engines": {
         "node": ">=14"
@@ -1306,17 +1283,33 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.33.0.tgz",
-      "integrity": "sha512-hGf6WMtJpoepHw4kJ4jYsos/45pq6PNHs3pc1PGm+Vbm7e4m6K1j4ZsRAPsWDw4AbYndFJd+u8YjphcPivhxFw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.34.0.tgz",
+      "integrity": "sha512-Ump/OyKxq1b4I01aBWSHJw8PCquZAHZh6ykplcmFBs9BZ8DIM7Jl3+zqrS8Vb7YcZ7DZTYORl8Xv/JQoQ+cFlw==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/otlp-exporter-base": "0.33.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.33.0",
-        "@opentelemetry/otlp-transformer": "0.33.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/sdk-trace-base": "1.7.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/otlp-exporter-base": "0.34.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.34.0",
+        "@opentelemetry/otlp-transformer": "0.34.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.8.0.tgz",
+      "integrity": "sha512-Y3WqNCZjfWKnHiRzb35sXpDfGL4Gx2qajFAv059s/VFayIPytLHUOrZMiQqrpfzU/TSIKPG4OHJaypFtUtNlQQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       },
       "engines": {
         "node": ">=14"
@@ -1326,11 +1319,10 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.33.0.tgz",
-      "integrity": "sha512-8joPjKJ6TznNt04JbnzZG+m1j/4wm1OIrX7DEw/V5lyZ9/2fahIqG72jeZ26VKOZnLOpVzUUnU/dweURqBzT3Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.33.0",
         "require-in-the-middle": "^5.0.3",
         "semver": "^7.3.2",
         "shimmer": "^1.2.1"
@@ -1339,15 +1331,15 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.33.0.tgz",
-      "integrity": "sha512-st+nsgv23BXSARFwugy6pheulDfOKjIFvzoYOUzPQDVhQtU8+l7dc50rIEybwXghb13o7mZs6Nb8KOvRk57qww==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.34.0.tgz",
+      "integrity": "sha512-xVNvQm7oXeQogeI21iTZRnBrBYS0OVekPutEJgb7jQtHg7x2GWuCBQK9sDo84FRWNXBpNOgSYqsf8/+PxIJ2vA==",
       "dependencies": {
-        "@opentelemetry/core": "1.7.0"
+        "@opentelemetry/core": "1.8.0"
       },
       "engines": {
         "node": ">=14"
@@ -1357,14 +1349,14 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.33.0.tgz",
-      "integrity": "sha512-TvM/IBctK/pzk1l98rZXXUjTY126QXEJmp8sFzbeVDjqaOBn/uuj8cLEed6oP1iIJo6QCW0tCtSb2WvZEbcz/g==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.34.0.tgz",
+      "integrity": "sha512-8k3CIVjf2+/kmnQNKIR8GtPIfRsQ5ZxBVh3uKof54stVXH/nX5ArceuQaoEfFoFQ8S8wayBZ1QsBwdab65UK0g==",
       "dependencies": {
-        "@grpc/grpc-js": "^1.5.9",
-        "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/otlp-exporter-base": "0.33.0"
+        "@grpc/grpc-js": "^1.7.1",
+        "@grpc/proto-loader": "^0.7.3",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/otlp-exporter-base": "0.34.0"
       },
       "engines": {
         "node": ">=14"
@@ -1374,13 +1366,12 @@
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.33.0.tgz",
-      "integrity": "sha512-DFJrqp4VoaFmUbo12Nlw9CxxmqQIa6Aq48OR7Ecv4sh3pf8vgztqak76EPIKlSrw2Fpuo352Dw+Y0nnDyEN15Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.34.0.tgz",
+      "integrity": "sha512-qHnwcAafW8OKeM2a1YQNoL9/sgWVE+JxvMgxf2CtYBqsccIakGPoQ43hLCFLAL3I2Af4BNb5t4KnW8lrtnyUjg==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/otlp-exporter-base": "0.33.0",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/otlp-exporter-base": "0.34.0",
         "protobufjs": "7.1.1"
       },
       "engines": {
@@ -1391,9 +1382,9 @@
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/long": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/protobufjs": {
       "version": "7.1.1",
@@ -1419,142 +1410,145 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.33.0.tgz",
-      "integrity": "sha512-L4OpsUaki9/Fib17t44YkDvAz3RpMZTtl6hYBhcTqAnqY0wVBpQf0ra25GyHQTKj+oiA//ZxvOlmmM/dXCYxoQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.34.0.tgz",
+      "integrity": "sha512-NghPJvn3pVoWBuhWyBe1n/nWIrj1D1EFUH/bIkWEp0CMVWFLux6R+BkRPZQo5klTcj8xFhCZZIZsL/ubkYPryg==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.33.0",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/sdk-metrics": "0.33.0",
-        "@opentelemetry/sdk-trace-base": "1.7.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/sdk-metrics": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.3.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.7.0.tgz",
-      "integrity": "sha512-8kKGS1KwArvkThdhubMZlomuREE9FaBcn9L4JrYHh2jly1FZpqOtFNO2byHymVRjH59d43Pa+eJuFpD0Fp7kSw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.8.0.tgz",
+      "integrity": "sha512-ffP6AVHyISqK1kiUY1MoVKt43Wp3FJXI8NOePqxBrAU7bRDJ13276VbSl4ugCZbZLTPrPhhSmvQh1WqlfUgcAg==",
       "dependencies": {
-        "@opentelemetry/core": "1.7.0"
+        "@opentelemetry/core": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.7.0.tgz",
-      "integrity": "sha512-V7i/L1bx+R/ve4z6dTdn2jtvFxGThRsXS2wNb/tWZVfV8gqnePQp+HfoLrqB/Yz2iRPUcMWrcjx6vV78umvJFA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.8.0.tgz",
+      "integrity": "sha512-v6GA38k2cqeGAh3368prLW5MsuG2/KxpfWI/PxTPjCa9tThDPq0cvhKpk7cEma3y+F6rieMhwmzZhKQL5QVBzQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.7.0"
+        "@opentelemetry/core": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.7.0.tgz",
-      "integrity": "sha512-u1M0yZotkjyKx8dj+46Sg5thwtOTBmtRieNXqdCRiWUp6SfFiIP0bI+1XK3LhuXqXkBXA1awJZaTqKduNMStRg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.8.0.tgz",
+      "integrity": "sha512-KSyMH6Jvss/PFDy16z5qkCK0ERlpyqixb1xwb73wLMvVq+j7i89lobDjw3JkpCcd1Ws0J6jAI4fw28Zufj2ssg==",
       "dependencies": {
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-0.33.0.tgz",
-      "integrity": "sha512-ZXPixOlTd/FHLwpkmm5nTpJE7bZOPfmbSz8hBVFCEHkXE1aKEKaM38UFnZ+2xzOY1tDsDwyxEiiBiDX8y3039A==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.8.0.tgz",
+      "integrity": "sha512-+KYb+uj0vHhl8xzJO+oChS4oP1e+/2Wl3SXoHoIdcEjd1TQfDV+lxOm4oqxWq6wykXvI35/JHyejxSoT+qxGmg==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.33.0",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/resources": "1.7.0",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/resources": "1.8.0",
         "lodash.merge": "4.6.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": ">=1.3.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.33.0.tgz",
-      "integrity": "sha512-wcXimvZOrFz+mRORoq+9OIusqoP8bnqbSF6U2XRUMQX986UoM6dAjwB5cslyRbrN4Feju+6tp70g6HTdl6BYMA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.34.0.tgz",
+      "integrity": "sha512-4OX2qvOPoK3De2e600Gim46I3PahI6UkD8uZ9hEgSg40egHXKw3keIaFnz1CWkYwa5hhVVIBsoobI41cHfulHA==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.33.0",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/instrumentation": "0.33.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/sdk-metrics": "0.33.0",
-        "@opentelemetry/sdk-trace-base": "1.7.0",
-        "@opentelemetry/sdk-trace-node": "1.7.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/exporter-jaeger": "1.8.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.34.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.34.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.34.0",
+        "@opentelemetry/exporter-zipkin": "1.8.0",
+        "@opentelemetry/instrumentation": "0.34.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/sdk-metrics": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
+        "@opentelemetry/sdk-trace-node": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.3.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.7.0.tgz",
-      "integrity": "sha512-Iz84C+FVOskmauh9FNnj4+VrA+hG5o+tkMzXuoesvSfunVSioXib0syVFeNXwOm4+M5GdWCuW632LVjqEXStIg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.8.0.tgz",
+      "integrity": "sha512-iH41m0UTddnCKJzZx3M85vlhKzRcmT48pUeBbnzsGrq4nIay1oWVHKM5nhB5r8qRDGvd/n7f/YLCXClxwM0tvA==",
       "dependencies": {
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.7.0.tgz",
-      "integrity": "sha512-DCAAbi0Zbb1pIofQcKzoAVy9/6bz24asFYeLb4fW/8QYAaawDnxumA++5Huw/RcYdJs8q8AIRBykwjYWWCm/5A==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.8.0.tgz",
+      "integrity": "sha512-6FqhJEgW9Nke5SO4Ul9+5EWOfms/JeLg5LRqILMPMK4UMBWcOtk7jldvGGyfVpraJ16/WPo/R5NSnMwlupN5zQ==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.7.0",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/propagator-b3": "1.7.0",
-        "@opentelemetry/propagator-jaeger": "1.7.0",
-        "@opentelemetry/sdk-trace-base": "1.7.0",
+        "@opentelemetry/context-async-hooks": "1.8.0",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/propagator-b3": "1.8.0",
+        "@opentelemetry/propagator-jaeger": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
         "semver": "^7.3.5"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
+        "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
-      "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
+      "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew==",
       "engines": {
         "node": ">=14"
       }
@@ -2074,6 +2068,14 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-color/-/ansi-color-0.2.1.tgz",
+      "integrity": "sha512-bF6xLaZBLpOQzgYUtYEhJx090nPSZk1BQ/q2oyBK9aMMcJHzx9uXGCjI2Y+LebsN4Jwoykr0V9whbPiogdyHoQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2377,6 +2379,20 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/bufrw": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bufrw/-/bufrw-1.3.0.tgz",
+      "integrity": "sha512-jzQnSbdJqhIltU9O5KUiTtljP9ccw2u5ix59McQy4pV2xGhVLhRZIndY8GIrgh5HjXa6+QJ9AQhOd2QWQizJFQ==",
+      "dependencies": {
+        "ansi-color": "^0.2.1",
+        "error": "^7.0.0",
+        "hexer": "^1.5.0",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.x"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -2665,6 +2681,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/error": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+      "integrity": "sha512-UtVv4l5MhijsYUxPJo4390gzfZvAnTHreNnDjnTZaKIiZ/SemXxAhBkYSKtWa5RtBXbLP8tMgn/n0RUa/H7jXw==",
+      "dependencies": {
+        "string-template": "~0.2.1",
+        "xtend": "~4.0.0"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -3653,6 +3678,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hexer": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hexer/-/hexer-1.5.0.tgz",
+      "integrity": "sha512-dyrPC8KzBzUJ19QTIo1gXNqIISRXQ0NwteW6OeQHRN4ZuZeHkdODfj0zHBdOlHbRY8GqbqK57C9oWSvQZizFsg==",
+      "dependencies": {
+        "ansi-color": "^0.2.1",
+        "minimist": "^1.1.0",
+        "process": "^0.10.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "hexer": "cli.js"
+      },
+      "engines": {
+        "node": ">= 0.10.x"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4067,6 +4109,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jaeger-client": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/jaeger-client/-/jaeger-client-3.19.0.tgz",
+      "integrity": "sha512-M0c7cKHmdyEUtjemnJyx/y9uX16XHocL46yQvyqDlPdvAcwPDbHrIbKjQdBqtiE4apQ/9dmr+ZLJYYPGnurgpw==",
+      "dependencies": {
+        "node-int64": "^0.4.0",
+        "opentracing": "^0.14.4",
+        "thriftrw": "^3.5.0",
+        "uuid": "^8.3.2",
+        "xorshift": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jest": {
@@ -4935,7 +4992,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4977,8 +5033,7 @@
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
     "node_modules/node-releases": {
       "version": "2.0.6",
@@ -5082,6 +5137,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opentracing": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
+      "integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/optionator": {
@@ -5352,6 +5415,14 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz",
+      "integrity": "sha512-dyIett8dgGIZ/TXKUzeYExt7WA6ldDzys9vTDU/cCA9L17Ypme+KzS+NjQCjpn9xsvi/shbMC+yP/BcFMBz0NA==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -5366,9 +5437,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
+      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -5381,14 +5452,17 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
       },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+      "engines": {
+        "node": ">=12.0.0"
       }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -5731,6 +5805,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/string-template": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw=="
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -5855,6 +5934,30 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/thriftrw": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/thriftrw/-/thriftrw-3.12.0.tgz",
+      "integrity": "sha512-4YZvR4DPEI41n4Opwr4jmrLGG4hndxr7387kzRFIIzxHQjarPusH4lGXrugvgb7TtPrfZVTpZCVe44/xUxowEw==",
+      "dependencies": {
+        "bufrw": "^1.3.0",
+        "error": "7.0.2",
+        "long": "^2.4.0"
+      },
+      "bin": {
+        "thrift2json": "thrift2json.js"
+      },
+      "engines": {
+        "node": ">= 0.10.x"
+      }
+    },
+    "node_modules/thriftrw/node_modules/long": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-2.4.0.tgz",
+      "integrity": "sha512-ijUtjmO/n2A5PaosNG9ZGDsQ3vxJg7ZW8vsY8Kp0f2yIZWhSJvjmegV7t+9RPQKxKrvj8yKGehhS+po14hPLGQ==",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -6080,7 +6183,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -6188,6 +6290,19 @@
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true
+    },
+    "node_modules/xorshift": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xorshift/-/xorshift-1.2.0.tgz",
+      "integrity": "sha512-iYgNnGyeeJ4t6U11NpA/QiKy+PXn5Aa3Azg5qkwIFz1tBLllQrjjsk9yzD7IAK0naNU4JxdeDgqW9ov4u/hc4g=="
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -6732,57 +6847,17 @@
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
-      },
-      "dependencies": {
-        "@grpc/proto-loader": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.3.tgz",
-          "integrity": "sha512-5dAvoZwna2Py3Ef96Ux9jIkp3iZ62TUsV00p3wVBPNX5K178UbNi8Q7gQVqwXT1Yq9RejIGG9G2IPEo93T6RcA==",
-          "requires": {
-            "@types/long": "^4.0.1",
-            "lodash.camelcase": "^4.3.0",
-            "long": "^4.0.0",
-            "protobufjs": "^7.0.0",
-            "yargs": "^16.2.0"
-          }
-        },
-        "protobufjs": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
-          "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
-          },
-          "dependencies": {
-            "long": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-              "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-            }
-          }
-        }
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
-      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.3.tgz",
+      "integrity": "sha512-5dAvoZwna2Py3Ef96Ux9jIkp3iZ62TUsV00p3wVBPNX5K178UbNi8Q7gQVqwXT1Yq9RejIGG9G2IPEo93T6RcA==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.11.3",
+        "protobufjs": "^7.0.0",
         "yargs": "^16.2.0"
       }
     },
@@ -7177,105 +7252,127 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.2.0.tgz",
-      "integrity": "sha512-0nBr+VZNKm9tvNDZFstI3Pq1fCTEDK5OZTnVKNvBNAKgd0yIvmwsP4m61rEv7ZP+tOUjWJhROpxK5MsnlF911g=="
-    },
-    "@opentelemetry/api-metrics": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz",
-      "integrity": "sha512-78evfPRRRnJA6uZ3xuBuS3VZlXTO/LRs+Ff1iv3O/7DgibCtq9k27T6Zlj8yRdJDFmcjcbQrvC0/CpDpWHaZYA==",
-      "requires": {
-        "@opentelemetry/api": "^1.0.0"
-      }
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
+      "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ=="
     },
     "@opentelemetry/context-async-hooks": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.7.0.tgz",
-      "integrity": "sha512-g4bMzyVW5dVBeMkyadaf3NRFpmNrdD4Pp9OJsrP29HwIam/zVMNfIWQpT5IBzjtTSMhl/ED5YQYR+UOSjVq3sQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.8.0.tgz",
+      "integrity": "sha512-ueLmocbWDi1aoU4IPdOQyt4qz/Dx+NYyU4qoa3d683usbnkDLUXYXJFfKIMPFV2BbrI5qtnpTtzErCKewoM8aw==",
       "requires": {}
     },
     "@opentelemetry/core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.7.0.tgz",
-      "integrity": "sha512-AVqAi5uc8DrKJBimCTFUT4iFI+5eXpo4sYmGbQ0CypG0piOTHE2g9c5aSoTGYXu3CzOmJZf7pT6Xh+nwm5d6yQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-6SDjwBML4Am0AQmy7z1j6HGrWDgeK8awBRUvl1PGw6HayViMk4QpnUXvv4HTHisecgVBy43NE/cstWprm8tIfw==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/semantic-conventions": "1.8.0"
+      }
+    },
+    "@opentelemetry/exporter-jaeger": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.8.0.tgz",
+      "integrity": "sha512-3h16Sb1T/G33S+RM3yjt1t2xRuu/mi9iB172faS6qFQEclTTJru1pTK4wuWG+9GyI7uyBLfbQoXVA5/BA6gvHw==",
+      "requires": {
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0",
+        "jaeger-client": "^3.15.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.33.0.tgz",
-      "integrity": "sha512-B+XGvNE5RcMlXkA8F9fdvr7hZ3Bvi1OGIW8iNicQ508A5OTpTrOHTXfkYdCjwPpAaZTGoxKJmAF2dwaAw76fmg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.34.0.tgz",
+      "integrity": "sha512-x1V0daRLS6k0dhBPNNLMOP+OSrh8M60Xs9/YkuZS0+/zdbcIjNvPzo/8+dK3zOJx+j1KF0oBX9zxK0SX3PSnZw==",
       "requires": {
-        "@grpc/grpc-js": "^1.5.9",
-        "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.33.0",
-        "@opentelemetry/otlp-transformer": "0.33.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/sdk-trace-base": "1.7.0"
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.34.0",
+        "@opentelemetry/otlp-transformer": "0.34.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0"
+      }
+    },
+    "@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.34.0.tgz",
+      "integrity": "sha512-MBtUwMvgpdoRo9iqK2eDJ8SP2xKYWeBCSu99s4cc1kg4HKKOpenXLE/6daGsSZ+QTPwd8j+9xMSd+hhBg+Bvzw==",
+      "requires": {
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/otlp-exporter-base": "0.34.0",
+        "@opentelemetry/otlp-transformer": "0.34.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.33.0.tgz",
-      "integrity": "sha512-hGf6WMtJpoepHw4kJ4jYsos/45pq6PNHs3pc1PGm+Vbm7e4m6K1j4ZsRAPsWDw4AbYndFJd+u8YjphcPivhxFw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.34.0.tgz",
+      "integrity": "sha512-Ump/OyKxq1b4I01aBWSHJw8PCquZAHZh6ykplcmFBs9BZ8DIM7Jl3+zqrS8Vb7YcZ7DZTYORl8Xv/JQoQ+cFlw==",
       "requires": {
-        "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/otlp-exporter-base": "0.33.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.33.0",
-        "@opentelemetry/otlp-transformer": "0.33.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/sdk-trace-base": "1.7.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/otlp-exporter-base": "0.34.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.34.0",
+        "@opentelemetry/otlp-transformer": "0.34.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0"
+      }
+    },
+    "@opentelemetry/exporter-zipkin": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.8.0.tgz",
+      "integrity": "sha512-Y3WqNCZjfWKnHiRzb35sXpDfGL4Gx2qajFAv059s/VFayIPytLHUOrZMiQqrpfzU/TSIKPG4OHJaypFtUtNlQQ==",
+      "requires": {
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.33.0.tgz",
-      "integrity": "sha512-8joPjKJ6TznNt04JbnzZG+m1j/4wm1OIrX7DEw/V5lyZ9/2fahIqG72jeZ26VKOZnLOpVzUUnU/dweURqBzT3Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.33.0",
         "require-in-the-middle": "^5.0.3",
         "semver": "^7.3.2",
         "shimmer": "^1.2.1"
       }
     },
     "@opentelemetry/otlp-exporter-base": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.33.0.tgz",
-      "integrity": "sha512-st+nsgv23BXSARFwugy6pheulDfOKjIFvzoYOUzPQDVhQtU8+l7dc50rIEybwXghb13o7mZs6Nb8KOvRk57qww==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.34.0.tgz",
+      "integrity": "sha512-xVNvQm7oXeQogeI21iTZRnBrBYS0OVekPutEJgb7jQtHg7x2GWuCBQK9sDo84FRWNXBpNOgSYqsf8/+PxIJ2vA==",
       "requires": {
-        "@opentelemetry/core": "1.7.0"
+        "@opentelemetry/core": "1.8.0"
       }
     },
     "@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.33.0.tgz",
-      "integrity": "sha512-TvM/IBctK/pzk1l98rZXXUjTY126QXEJmp8sFzbeVDjqaOBn/uuj8cLEed6oP1iIJo6QCW0tCtSb2WvZEbcz/g==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.34.0.tgz",
+      "integrity": "sha512-8k3CIVjf2+/kmnQNKIR8GtPIfRsQ5ZxBVh3uKof54stVXH/nX5ArceuQaoEfFoFQ8S8wayBZ1QsBwdab65UK0g==",
       "requires": {
-        "@grpc/grpc-js": "^1.5.9",
-        "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/otlp-exporter-base": "0.33.0"
+        "@grpc/grpc-js": "^1.7.1",
+        "@grpc/proto-loader": "^0.7.3",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/otlp-exporter-base": "0.34.0"
       }
     },
     "@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.33.0.tgz",
-      "integrity": "sha512-DFJrqp4VoaFmUbo12Nlw9CxxmqQIa6Aq48OR7Ecv4sh3pf8vgztqak76EPIKlSrw2Fpuo352Dw+Y0nnDyEN15Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.34.0.tgz",
+      "integrity": "sha512-qHnwcAafW8OKeM2a1YQNoL9/sgWVE+JxvMgxf2CtYBqsccIakGPoQ43hLCFLAL3I2Af4BNb5t4KnW8lrtnyUjg==",
       "requires": {
-        "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/otlp-exporter-base": "0.33.0",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/otlp-exporter-base": "0.34.0",
         "protobufjs": "7.1.1"
       },
       "dependencies": {
         "long": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-          "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
         },
         "protobufjs": {
           "version": "7.1.1",
@@ -7299,94 +7396,97 @@
       }
     },
     "@opentelemetry/otlp-transformer": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.33.0.tgz",
-      "integrity": "sha512-L4OpsUaki9/Fib17t44YkDvAz3RpMZTtl6hYBhcTqAnqY0wVBpQf0ra25GyHQTKj+oiA//ZxvOlmmM/dXCYxoQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.34.0.tgz",
+      "integrity": "sha512-NghPJvn3pVoWBuhWyBe1n/nWIrj1D1EFUH/bIkWEp0CMVWFLux6R+BkRPZQo5klTcj8xFhCZZIZsL/ubkYPryg==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.33.0",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/sdk-metrics": "0.33.0",
-        "@opentelemetry/sdk-trace-base": "1.7.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/sdk-metrics": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0"
       }
     },
     "@opentelemetry/propagator-b3": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.7.0.tgz",
-      "integrity": "sha512-8kKGS1KwArvkThdhubMZlomuREE9FaBcn9L4JrYHh2jly1FZpqOtFNO2byHymVRjH59d43Pa+eJuFpD0Fp7kSw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.8.0.tgz",
+      "integrity": "sha512-ffP6AVHyISqK1kiUY1MoVKt43Wp3FJXI8NOePqxBrAU7bRDJ13276VbSl4ugCZbZLTPrPhhSmvQh1WqlfUgcAg==",
       "requires": {
-        "@opentelemetry/core": "1.7.0"
+        "@opentelemetry/core": "1.8.0"
       }
     },
     "@opentelemetry/propagator-jaeger": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.7.0.tgz",
-      "integrity": "sha512-V7i/L1bx+R/ve4z6dTdn2jtvFxGThRsXS2wNb/tWZVfV8gqnePQp+HfoLrqB/Yz2iRPUcMWrcjx6vV78umvJFA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.8.0.tgz",
+      "integrity": "sha512-v6GA38k2cqeGAh3368prLW5MsuG2/KxpfWI/PxTPjCa9tThDPq0cvhKpk7cEma3y+F6rieMhwmzZhKQL5QVBzQ==",
       "requires": {
-        "@opentelemetry/core": "1.7.0"
+        "@opentelemetry/core": "1.8.0"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.7.0.tgz",
-      "integrity": "sha512-u1M0yZotkjyKx8dj+46Sg5thwtOTBmtRieNXqdCRiWUp6SfFiIP0bI+1XK3LhuXqXkBXA1awJZaTqKduNMStRg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.8.0.tgz",
+      "integrity": "sha512-KSyMH6Jvss/PFDy16z5qkCK0ERlpyqixb1xwb73wLMvVq+j7i89lobDjw3JkpCcd1Ws0J6jAI4fw28Zufj2ssg==",
       "requires": {
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-0.33.0.tgz",
-      "integrity": "sha512-ZXPixOlTd/FHLwpkmm5nTpJE7bZOPfmbSz8hBVFCEHkXE1aKEKaM38UFnZ+2xzOY1tDsDwyxEiiBiDX8y3039A==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.8.0.tgz",
+      "integrity": "sha512-+KYb+uj0vHhl8xzJO+oChS4oP1e+/2Wl3SXoHoIdcEjd1TQfDV+lxOm4oqxWq6wykXvI35/JHyejxSoT+qxGmg==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.33.0",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/resources": "1.7.0",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/resources": "1.8.0",
         "lodash.merge": "4.6.2"
       }
     },
     "@opentelemetry/sdk-node": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.33.0.tgz",
-      "integrity": "sha512-wcXimvZOrFz+mRORoq+9OIusqoP8bnqbSF6U2XRUMQX986UoM6dAjwB5cslyRbrN4Feju+6tp70g6HTdl6BYMA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.34.0.tgz",
+      "integrity": "sha512-4OX2qvOPoK3De2e600Gim46I3PahI6UkD8uZ9hEgSg40egHXKw3keIaFnz1CWkYwa5hhVVIBsoobI41cHfulHA==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.33.0",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/instrumentation": "0.33.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/sdk-metrics": "0.33.0",
-        "@opentelemetry/sdk-trace-base": "1.7.0",
-        "@opentelemetry/sdk-trace-node": "1.7.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/exporter-jaeger": "1.8.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.34.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.34.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.34.0",
+        "@opentelemetry/exporter-zipkin": "1.8.0",
+        "@opentelemetry/instrumentation": "0.34.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/sdk-metrics": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
+        "@opentelemetry/sdk-trace-node": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.7.0.tgz",
-      "integrity": "sha512-Iz84C+FVOskmauh9FNnj4+VrA+hG5o+tkMzXuoesvSfunVSioXib0syVFeNXwOm4+M5GdWCuW632LVjqEXStIg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.8.0.tgz",
+      "integrity": "sha512-iH41m0UTddnCKJzZx3M85vlhKzRcmT48pUeBbnzsGrq4nIay1oWVHKM5nhB5r8qRDGvd/n7f/YLCXClxwM0tvA==",
       "requires": {
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/resources": "1.7.0",
-        "@opentelemetry/semantic-conventions": "1.7.0"
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/sdk-trace-node": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.7.0.tgz",
-      "integrity": "sha512-DCAAbi0Zbb1pIofQcKzoAVy9/6bz24asFYeLb4fW/8QYAaawDnxumA++5Huw/RcYdJs8q8AIRBykwjYWWCm/5A==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.8.0.tgz",
+      "integrity": "sha512-6FqhJEgW9Nke5SO4Ul9+5EWOfms/JeLg5LRqILMPMK4UMBWcOtk7jldvGGyfVpraJ16/WPo/R5NSnMwlupN5zQ==",
       "requires": {
-        "@opentelemetry/context-async-hooks": "1.7.0",
-        "@opentelemetry/core": "1.7.0",
-        "@opentelemetry/propagator-b3": "1.7.0",
-        "@opentelemetry/propagator-jaeger": "1.7.0",
-        "@opentelemetry/sdk-trace-base": "1.7.0",
+        "@opentelemetry/context-async-hooks": "1.8.0",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/propagator-b3": "1.8.0",
+        "@opentelemetry/propagator-jaeger": "1.8.0",
+        "@opentelemetry/sdk-trace-base": "1.8.0",
         "semver": "^7.3.5"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.7.0.tgz",
-      "integrity": "sha512-FGBx/Qd09lMaqQcogCHyYrFEpTx4cAjeS+48lMIR12z7LdH+zofGDVQSubN59nL6IpubfKqTeIDu9rNO28iHVA=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
+      "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -7771,6 +7871,11 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ansi-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-color/-/ansi-color-0.2.1.tgz",
+      "integrity": "sha512-bF6xLaZBLpOQzgYUtYEhJx090nPSZk1BQ/q2oyBK9aMMcJHzx9uXGCjI2Y+LebsN4Jwoykr0V9whbPiogdyHoQ=="
+    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -7994,6 +8099,17 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "bufrw": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bufrw/-/bufrw-1.3.0.tgz",
+      "integrity": "sha512-jzQnSbdJqhIltU9O5KUiTtljP9ccw2u5ix59McQy4pV2xGhVLhRZIndY8GIrgh5HjXa6+QJ9AQhOd2QWQizJFQ==",
+      "requires": {
+        "ansi-color": "^0.2.1",
+        "error": "^7.0.0",
+        "hexer": "^1.5.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -8203,6 +8319,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "error": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+      "integrity": "sha512-UtVv4l5MhijsYUxPJo4390gzfZvAnTHreNnDjnTZaKIiZ/SemXxAhBkYSKtWa5RtBXbLP8tMgn/n0RUa/H7jXw==",
+      "requires": {
+        "string-template": "~0.2.1",
+        "xtend": "~4.0.0"
+      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -8933,6 +9058,17 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "hexer": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hexer/-/hexer-1.5.0.tgz",
+      "integrity": "sha512-dyrPC8KzBzUJ19QTIo1gXNqIISRXQ0NwteW6OeQHRN4ZuZeHkdODfj0zHBdOlHbRY8GqbqK57C9oWSvQZizFsg==",
+      "requires": {
+        "ansi-color": "^0.2.1",
+        "minimist": "^1.1.0",
+        "process": "^0.10.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -9220,6 +9356,18 @@
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "jaeger-client": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/jaeger-client/-/jaeger-client-3.19.0.tgz",
+      "integrity": "sha512-M0c7cKHmdyEUtjemnJyx/y9uX16XHocL46yQvyqDlPdvAcwPDbHrIbKjQdBqtiE4apQ/9dmr+ZLJYYPGnurgpw==",
+      "requires": {
+        "node-int64": "^0.4.0",
+        "opentracing": "^0.14.4",
+        "thriftrw": "^3.5.0",
+        "uuid": "^8.3.2",
+        "xorshift": "^1.1.1"
       }
     },
     "jest": {
@@ -9893,8 +10041,7 @@
     "minimist": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-      "dev": true
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
     },
     "mkdirp": {
       "version": "1.0.4",
@@ -9927,8 +10074,7 @@
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
     "node-releases": {
       "version": "2.0.6",
@@ -10003,6 +10149,11 @@
       "requires": {
         "mimic-fn": "^2.1.0"
       }
+    },
+    "opentracing": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
+      "integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q=="
     },
     "optionator": {
       "version": "0.9.1",
@@ -10189,6 +10340,11 @@
         }
       }
     },
+    "process": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz",
+      "integrity": "sha512-dyIett8dgGIZ/TXKUzeYExt7WA6ldDzys9vTDU/cCA9L17Ypme+KzS+NjQCjpn9xsvi/shbMC+yP/BcFMBz0NA=="
+    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -10200,9 +10356,9 @@
       }
     },
     "protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
+      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -10214,9 +10370,15 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
+      },
+      "dependencies": {
+        "long": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+        }
       }
     },
     "proxy-from-env": {
@@ -10454,6 +10616,11 @@
         "strip-ansi": "^6.0.0"
       }
     },
+    "string-template": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw=="
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -10542,6 +10709,23 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "thriftrw": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/thriftrw/-/thriftrw-3.12.0.tgz",
+      "integrity": "sha512-4YZvR4DPEI41n4Opwr4jmrLGG4hndxr7387kzRFIIzxHQjarPusH4lGXrugvgb7TtPrfZVTpZCVe44/xUxowEw==",
+      "requires": {
+        "bufrw": "^1.3.0",
+        "error": "7.0.2",
+        "long": "^2.4.0"
+      },
+      "dependencies": {
+        "long": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-2.4.0.tgz",
+          "integrity": "sha512-ijUtjmO/n2A5PaosNG9ZGDsQ3vxJg7ZW8vsY8Kp0f2yIZWhSJvjmegV7t+9RPQKxKrvj8yKGehhS+po14hPLGQ=="
+        }
+      }
     },
     "tmpl": {
       "version": "1.0.5",
@@ -10685,8 +10869,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-to-istanbul": {
       "version": "9.0.1",
@@ -10767,6 +10950,16 @@
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true
+    },
+    "xorshift": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xorshift/-/xorshift-1.2.0.tgz",
+      "integrity": "sha512-iYgNnGyeeJ4t6U11NpA/QiKy+PXn5Aa3Azg5qkwIFz1tBLllQrjjsk9yzD7IAK0naNU4JxdeDgqW9ov4u/hc4g=="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -58,12 +58,12 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.3",
-    "@opentelemetry/api": "^1.2.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "^0.33.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "^0.33.0",
-    "@opentelemetry/resources": "^1.7.0",
-    "@opentelemetry/sdk-node": "^0.33.0",
-    "@opentelemetry/sdk-trace-base": "^1.7.0",
+    "@opentelemetry/api": "^1.3.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.34.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.34.0",
+    "@opentelemetry/resources": "^1.8.0",
+    "@opentelemetry/sdk-node": "^0.34.0",
+    "@opentelemetry/sdk-trace-base": "^1.8.0",
     "axios": "^1.1.3"
   }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

When installing in a new app, version conflicts caused the instrumentation to not work properly.

More investigation may be needed to help reduce conflicts in the future, but right now it seems that the most reliable usage is to use more current versions and to have the same versions in our dependencies and in end user apps, especially for the `api` and `auto-instrumentations-node` packages.

## Short description of the changes

```text
    "@opentelemetry/api": "^1.2.0", --> "^1.3.0"
    "@opentelemetry/exporter-trace-otlp-grpc": "^0.33.0", --> "^0.34.0"
    "@opentelemetry/exporter-trace-otlp-proto": "^0.33.0", --> "^0.34.0"
    "@opentelemetry/resources": "^1.7.0", --> "^1.8.0"
    "@opentelemetry/sdk-node": "^0.33.0", --> "^0.34.0"
    "@opentelemetry/sdk-trace-base": "^1.7.0",--> "^1.8.0"
```

Also, notes were added into `DEVELOPING.md` about how to package as a tarball for easier local development in other projects. 

## How to verify that this has the expected result

install `@honeycombio/opentelemetry-node`, `@opentelemetry/api`, and `@opentelemetry/auto-instrumentations-node`, ensuring versions `v0.1.1-beta`, `1.3.0`, and `0.34.0` are installed respectively. Use as instructed in the docs, and see both auto- and manual instrumentation. Also smoke tests should work.

Co-authored-by: Purvi Kanal <purvikanal@honeycomb.io>