### PR TITLE
feat: support enum-style protocol specification

### DIFF
--- a/src/honeycomb-options.ts
+++ b/src/honeycomb-options.ts
@@ -1,11 +1,16 @@
 import { NodeSDKConfiguration } from '@opentelemetry/sdk-node';
 
+export const OtlpProtocols = ['grpc', 'http/protobuf', 'http/json'] as const;
+export enum OtlpProtocolKind {
+  Grpc = 'grpc',
+  HttpProtobuf = 'http/protobuf',
+  HttpJson = 'http/json'
+}
+export type OtlpProtocol = OtlpProtocolKind | typeof OtlpProtocols[number]
+
 export const DEFAULT_API_ENDPOINT = 'https://api.honeycomb.io';
 export const DEFAULT_SAMPLE_RATE = 1;
-export const DEFAULT_OTLP_EXPORTER_PROTOCOL = 'http/protobuf';
-
-export const OtlpProtocols = ['grpc', 'http/protobuf', 'http/json'] as const;
-type OtlpProtocol = typeof OtlpProtocols[number];
+export const DEFAULT_OTLP_EXPORTER_PROTOCOL = OtlpProtocolKind.HttpProtobuf;
 
 export const IGNORED_DATASET_ERROR =
   'WARN: Dataset is ignored in favor of service name.';

--- a/src/honeycomb-options.ts
+++ b/src/honeycomb-options.ts
@@ -4,9 +4,9 @@ export const OtlpProtocols = ['grpc', 'http/protobuf', 'http/json'] as const;
 export enum OtlpProtocolKind {
   Grpc = 'grpc',
   HttpProtobuf = 'http/protobuf',
-  HttpJson = 'http/json'
+  HttpJson = 'http/json',
 }
-export type OtlpProtocol = OtlpProtocolKind | typeof OtlpProtocols[number]
+export type OtlpProtocol = OtlpProtocolKind | typeof OtlpProtocols[number];
 
 export const DEFAULT_API_ENDPOINT = 'https://api.honeycomb.io';
 export const DEFAULT_SAMPLE_RATE = 1;

--- a/test/honeycomb-options.test.ts
+++ b/test/honeycomb-options.test.ts
@@ -8,6 +8,7 @@ import {
   MISSING_API_KEY_ERROR,
   MISSING_DATASET_ERROR,
   MISSING_SERVICE_NAME_ERROR,
+  OtlpProtocolKind,
 } from '../src/honeycomb-options';
 
 // classic keys are 32 chars long
@@ -334,7 +335,7 @@ describe('metrics endpoint', () => {
   it('does not append path for grpc exporter protocol', () => {
     const options = computeOptions({
       metricsEndpoint: 'my-custom-endpoint',
-      protocol: 'grpc',
+      protocol: OtlpProtocolKind.Grpc,
     });
     expect(options.metricsEndpoint).toBe('my-custom-endpoint');
   });

--- a/test/honeycomb-options.test.ts
+++ b/test/honeycomb-options.test.ts
@@ -338,6 +338,7 @@ describe('metrics endpoint', () => {
       protocol: OtlpProtocolKind.Grpc,
     });
     expect(options.metricsEndpoint).toBe('my-custom-endpoint');
+    expect(options.protocol).toBe('grpc');
   });
 });
 


### PR DESCRIPTION
This lets you get a strongly-typed protocol type when you're using typescript but still supports the stringy-wingy kind as well.

```ts
const sdk = new HoneycombSdk({
  protocol: OtlpProtocolKind.Grpc
});
```

And also:

```js
const sdk = new HoneycombSdk({
  protocol: 'grpc'
});
```