### PR TITLE
feat: Export `HoneycombOptions` type

### DIFF
--- a/examples/hello-node-express-ts/index.ts
+++ b/examples/hello-node-express-ts/index.ts
@@ -1,11 +1,12 @@
 import {
-  Context,
   context,
+  Context,
   propagation,
+  Span,
   trace,
-  Tracer,
+  Tracer
 } from '@opentelemetry/api';
-import express, { Express, Request, Response } from 'express';
+import express, { Express, NextFunction, Request, Response } from 'express';
 
 const app: Express = express();
 const hostname = '0.0.0.0';
@@ -13,7 +14,7 @@ const port = 3000;
 
 // express supports async handlers but the @types definition is wrong: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/50871
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
-app.get('/', async (_req: Request, res: Response, next: any) => {
+app.get('/', async (_req: Request, res: Response, next: NextFunction) => {
   try {
     res.statusCode = 200;
     res.setHeader('Content-Type', 'text/plain');
@@ -28,7 +29,7 @@ app.get('/', async (_req: Request, res: Response, next: any) => {
     );
     // within the new context, do some "work"
     await context.with(ctx, async () => {
-      await tracer.startActiveSpan('sleep', async (span) => {
+      await tracer.startActiveSpan('sleep', async (span: Span) => {
         console.log('saying hello to the world');
         span.setAttribute('message', 'hello-world');
         span.setAttribute('delay_ms', 100);

--- a/examples/hello-node-express-ts/index.ts
+++ b/examples/hello-node-express-ts/index.ts
@@ -4,7 +4,7 @@ import {
   propagation,
   Span,
   trace,
-  Tracer
+  Tracer,
 } from '@opentelemetry/api';
 import express, { Express, NextFunction, Request, Response } from 'express';
 

--- a/examples/hello-node-express-ts/instrumentation.ts
+++ b/examples/hello-node-express-ts/instrumentation.ts
@@ -1,5 +1,8 @@
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import { HoneycombOptions, HoneycombSDK } from '@honeycombio/opentelemetry-node';
+import {
+  HoneycombOptions,
+  HoneycombSDK,
+} from '@honeycombio/opentelemetry-node';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 
 const config: HoneycombOptions = {
@@ -7,7 +10,7 @@ const config: HoneycombOptions = {
   serviceName: process.env.OTEL_SERVICE_NAME || 'hello-node-express-ts',
   debug: true,
   instrumentations: [getNodeAutoInstrumentations()],
-}
+};
 
 const sdk: NodeSDK = new HoneycombSDK(config);
 

--- a/examples/hello-node-express-ts/instrumentation.ts
+++ b/examples/hello-node-express-ts/instrumentation.ts
@@ -1,13 +1,15 @@
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import { HoneycombSDK } from '@honeycombio/opentelemetry-node';
+import { HoneycombOptions, HoneycombSDK } from '@honeycombio/opentelemetry-node';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 
-const sdk: NodeSDK = new HoneycombSDK({
+const config: HoneycombOptions = {
   apiKey: process.env.HONEYCOMB_API_KEY || '',
   serviceName: process.env.OTEL_SERVICE_NAME || 'hello-node-express-ts',
   debug: true,
   instrumentations: [getNodeAutoInstrumentations()],
-});
+}
+
+const sdk: NodeSDK = new HoneycombSDK(config);
 
 sdk
   .start()

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export { configureHoneycombHttpProtoTraceExporter } from './http-proto-trace-exp
 export { configureDeterministicSampler } from './deterministic-sampler';
 export { configureHoneycombGrpcTraceExporter } from './grpc-trace-exporter';
 export { configureBatchWithBaggageSpanProcessor } from './baggage-span-processor';
+export { HoneycombOptions } from './honeycomb-options';


### PR DESCRIPTION
## Which problem is this PR solving?
Exposes the `HoneycombOptions` type created in the distro that extends the OTel Node SDK config options. Exposing this type allows users to type check their config. TS / linters will be able to pick up if an incorrect config option is used.

## Short description of the changes
- Export `HoneycombOptions` type
- Update TS example with typed config object
- Update TS example with some more types from OTel

## How to verify that this has the expected result
- Try passing in a key to the config object in the example that isn't a part of the `HoneycombOptions` type, TS won't  compile and there should be linter warnings. 
