### PR TITLE
ci: add PR comment for failed title check & ignore dependabot PRs

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -29,3 +29,27 @@ jobs:
             refactor
             perf
             test
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Thank you for contributing to the project! 🎉
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+            Make sure to prepend with "feat:", "fix:", or another option in the list below.
+            Once you update the title, this workflow will re-run automatically and validate the updated title.
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -31,6 +31,8 @@ jobs:
             refactor
             perf
             test
+          ignoreLabels: |
+            "type: dependencies"
       # When the previous steps fails, the workflow would stop. By adding this
       # condition you can continue the execution with the populated error message.
       - if: always() && (steps.lint_pr_title.outputs.error_message != null)

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -29,10 +29,10 @@ jobs:
             refactor
             perf
             test
-      - uses: marocchino/sticky-pull-request-comment@v2
-        # When the previous steps fails, the workflow would stop. By adding this
-        # condition you can continue the execution with the populated error message.
-        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+      # When the previous steps fails, the workflow would stop. By adding this
+      # condition you can continue the execution with the populated error message.
+      - if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr-title-lint-error
           message: |

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        name: "🤖 Check PR title follows conventional commit spec"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -32,6 +34,7 @@ jobs:
       # When the previous steps fails, the workflow would stop. By adding this
       # condition you can continue the execution with the populated error message.
       - if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        name: "📝 Add PR comment about using conventional commit spec"
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr-title-lint-error
@@ -49,6 +52,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        name: "❌ Delete PR comment after title has been updated"
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr-title-lint-error

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -42,8 +42,11 @@ jobs:
             Thank you for contributing to the project! 🎉
 
             We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
-            Make sure to prepend with "feat:", "fix:", or another option in the list below.
+
+            Make sure to prepend with `feat:`, `fix:`, or another option in the list below.
+
             Once you update the title, this workflow will re-run automatically and validate the updated title.
+
             Details:
 
             ```


### PR DESCRIPTION
## Which problem is this PR solving?
Adds a better error message when the PR title conventional commit check fails. We'll use this PR as the main PR to review before applying it to the other repos.

## Short description of the changes
- If the conventional commit check for PR titles fails, a comment appears on the PR with a friendly error message
- Once the title has been updated, the comment is deleted
- Added an option to ignore PR title validation for PRs with the label `type: dependencies` so that dependabot PRs are ignored.

## How to verify that this has the expected result
1. Remove the conventional commit prefix from this PRs title
2. After the step fails, a comment should appear on the PR
3. Add the prefix back to the title
4. The comment should be deleted from the PR

## Tests I've done
- [x] If the conventional commit check fails, there should be a comment on the PR
- [x] If the check fails for subsequent commits that are pushed, there should only be one comment
- [x] Once the PR title is up to spec, the comment is deleted
- [x] The check does not run if the PR has the label `type: dependencies`

## Example of comment
![Screen Shot 2022-11-28 at 3 48 22 PM](https://user-images.githubusercontent.com/8810222/204379699-aab65fc7-8c48-4f69-b2f2-ddac12f15597.png)
