### PR TITLE
fix: add semantic commit prefix to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       - "type: dependencies"
     reviewers:
       - "honeycombio/telemetry-team"
+    commit-message:
+      prefix: "maint"
+      include_scope: true


### PR DESCRIPTION
## Which problem is this PR solving?
Our dependabot PRs are failing CI checks because of the PR title validation check. Instead of getting the PR title validation check to ignore dependabot PRs, I thought it would be better to add the correct semantic prefix to dependabot PRs instead.

- Updates https://github.com/honeycombio/telemetry-team/issues/389

## Short description of the changes
- Adds semantic prefix `maint` to all dependabot commits / PRs

## How to verify that this has the expected result
Unfortunately, it doesn't seem like we can validate dependabot config changes without merging them in according to [this issue](https://github.com/dependabot/dependabot-core/issues/4605).

I think this should work as expected based on:
- [The dependabot docs for `commit-message`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message)
- [The code adds a `:` and a space automatically
](https://github.com/dependabot/dependabot-core/blob/main/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb#L248)
