### PR TITLE
chore: add metrics tests to smoke tests

### DIFF
--- a/examples/hello-node-express-ts/index.ts
+++ b/examples/hello-node-express-ts/index.ts
@@ -1,6 +1,7 @@
 import {
   context,
   Context,
+  Counter,
   Meter,
   metrics,
   propagation,
@@ -23,7 +24,8 @@ app.get('/', async (_req: Request, res: Response, next: NextFunction) => {
     const sayHello = () => 'Hello world!';
     const tracer: Tracer = trace.getTracer('hello-world-tracer');
     const meter: Meter = metrics.getMeter('hello-world-meter');
-    const counter = meter.createCounter('events.counter');
+    const counter: Counter = meter.createCounter('sheep');
+
     counter.add(1);
     // new context based on current, with key/values added to baggage
     const ctx: Context = propagation.setBaggage(

--- a/examples/hello-node-express-ts/package-lock.json
+++ b/examples/hello-node-express-ts/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@honeycombio/opentelemetry-node": "file:../../dist/src",
         "@opentelemetry/auto-instrumentations-node": "^0.35.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "^0.34.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
         "express": "^4.18.2"
       },
@@ -228,44 +227,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.4.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.34.0.tgz",
-      "integrity": "sha512-ToRJA4frErHGiKKnPCI3+cvdyK8rksRI+mV6xZ6Yt7HiIrArY9eDX7QaCEZcTLbQIib09LTlCX87TKEL3TToWQ==",
-      "dependencies": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-transformer": "0.34.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.8.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.34.0.tgz",
-      "integrity": "sha512-l9748EtVH+wl1MWFptiRdieS9OkZgGkG4jQRDj+BGIxKJifIiVu6E2o6y+31fkxVzpLAtcxjAG/far0HHpPeZg==",
-      "dependencies": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.34.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-transformer": "0.34.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.8.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
@@ -863,53 +824,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.34.0.tgz",
-      "integrity": "sha512-xVNvQm7oXeQogeI21iTZRnBrBYS0OVekPutEJgb7jQtHg7x2GWuCBQK9sDo84FRWNXBpNOgSYqsf8/+PxIJ2vA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.8.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.34.0.tgz",
-      "integrity": "sha512-qHnwcAafW8OKeM2a1YQNoL9/sgWVE+JxvMgxf2CtYBqsccIakGPoQ43hLCFLAL3I2Af4BNb5t4KnW8lrtnyUjg==",
-      "dependencies": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0",
-        "protobufjs": "7.1.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.34.0.tgz",
-      "integrity": "sha512-NghPJvn3pVoWBuhWyBe1n/nWIrj1D1EFUH/bIkWEp0CMVWFLux6R+BkRPZQo5klTcj8xFhCZZIZsL/ubkYPryg==",
-      "dependencies": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.8.0",
-        "@opentelemetry/sdk-trace-base": "1.8.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.4.0"
-      }
-    },
     "node_modules/@opentelemetry/propagation-utils": {
       "version": "0.29.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.29.1.tgz",
@@ -966,22 +880,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.4.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.8.0.tgz",
-      "integrity": "sha512-iH41m0UTddnCKJzZx3M85vlhKzRcmT48pUeBbnzsGrq4nIay1oWVHKM5nhB5r8qRDGvd/n7f/YLCXClxwM0tvA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/semantic-conventions": "1.8.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.4.0"
-      }
-    },
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
@@ -989,60 +887,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
@@ -1723,11 +1567,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
-    "node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -1912,29 +1751,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/protobufjs": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.1.tgz",
-      "integrity": "sha512-d0nMQqS/aT3lfV8bKi9Gbg73vPd2LcDdTDOu6RE/M+h9DY8g1EmDzk3ADPccthEWfTBjkR2oxNdx9Gs8YubT+g==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -2464,32 +2280,6 @@
         "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
-    "@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.34.0.tgz",
-      "integrity": "sha512-ToRJA4frErHGiKKnPCI3+cvdyK8rksRI+mV6xZ6Yt7HiIrArY9eDX7QaCEZcTLbQIib09LTlCX87TKEL3TToWQ==",
-      "requires": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-transformer": "0.34.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.8.0"
-      }
-    },
-    "@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.34.0.tgz",
-      "integrity": "sha512-l9748EtVH+wl1MWFptiRdieS9OkZgGkG4jQRDj+BGIxKJifIiVu6E2o6y+31fkxVzpLAtcxjAG/far0HHpPeZg==",
-      "requires": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.34.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-transformer": "0.34.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.8.0"
-      }
-    },
     "@opentelemetry/instrumentation": {
       "version": "0.34.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
@@ -2867,35 +2657,6 @@
         "@opentelemetry/instrumentation": "^0.34.0"
       }
     },
-    "@opentelemetry/otlp-exporter-base": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.34.0.tgz",
-      "integrity": "sha512-xVNvQm7oXeQogeI21iTZRnBrBYS0OVekPutEJgb7jQtHg7x2GWuCBQK9sDo84FRWNXBpNOgSYqsf8/+PxIJ2vA==",
-      "requires": {
-        "@opentelemetry/core": "1.8.0"
-      }
-    },
-    "@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.34.0.tgz",
-      "integrity": "sha512-qHnwcAafW8OKeM2a1YQNoL9/sgWVE+JxvMgxf2CtYBqsccIakGPoQ43hLCFLAL3I2Af4BNb5t4KnW8lrtnyUjg==",
-      "requires": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0",
-        "protobufjs": "7.1.1"
-      }
-    },
-    "@opentelemetry/otlp-transformer": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.34.0.tgz",
-      "integrity": "sha512-NghPJvn3pVoWBuhWyBe1n/nWIrj1D1EFUH/bIkWEp0CMVWFLux6R+BkRPZQo5klTcj8xFhCZZIZsL/ubkYPryg==",
-      "requires": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.8.0",
-        "@opentelemetry/sdk-trace-base": "1.8.0"
-      }
-    },
     "@opentelemetry/propagation-utils": {
       "version": "0.29.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.29.1.tgz",
@@ -2929,74 +2690,10 @@
         "lodash.merge": "4.6.2"
       }
     },
-    "@opentelemetry/sdk-trace-base": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.8.0.tgz",
-      "integrity": "sha512-iH41m0UTddnCKJzZx3M85vlhKzRcmT48pUeBbnzsGrq4nIay1oWVHKM5nhB5r8qRDGvd/n7f/YLCXClxwM0tvA==",
-      "requires": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/semantic-conventions": "1.8.0"
-      }
-    },
     "@opentelemetry/semantic-conventions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
       "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew=="
-    },
-    "@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
-    },
-    "@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    },
-    "@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    },
-    "@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
-    },
-    "@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-    },
-    "@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
-    },
-    "@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
-    },
-    "@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
-    },
-    "@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@sideway/address": {
       "version": "4.1.4",
@@ -3594,11 +3291,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
-    "long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -3732,25 +3424,6 @@
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "requires": {
         "xtend": "^4.0.0"
-      }
-    },
-    "protobufjs": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.1.tgz",
-      "integrity": "sha512-d0nMQqS/aT3lfV8bKi9Gbg73vPd2LcDdTDOu6RE/M+h9DY8g1EmDzk3ADPccthEWfTBjkR2oxNdx9Gs8YubT+g==",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
       }
     },
     "proxy-addr": {

--- a/examples/hello-node-express-ts/package.json
+++ b/examples/hello-node-express-ts/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@honeycombio/opentelemetry-node": "file:../../dist/src",
     "@opentelemetry/auto-instrumentations-node": "^0.35.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "^0.34.0",
     "@opentelemetry/sdk-metrics": "^1.8.0",
     "express": "^4.18.2"
   },

--- a/examples/hello-node-express/index.js
+++ b/examples/hello-node-express/index.js
@@ -1,5 +1,5 @@
 const { HoneycombSDK } = require('@honeycombio/opentelemetry-node');
-const { context, propagation, trace } = require('@opentelemetry/api');
+const { context, metrics, propagation, trace } = require('@opentelemetry/api');
 const {
   getNodeAutoInstrumentations,
 } = require('@opentelemetry/auto-instrumentations-node');
@@ -9,9 +9,12 @@ const sdk = new HoneycombSDK({
   serviceName: process.env.OTEL_SERVICE_NAME || 'hello-node-express',
   debug: true,
   instrumentations: [getNodeAutoInstrumentations()],
+  metricsDataset:
+    process.env.HONEYCOMB_METRICS_DATASET || 'hello-node-express-ts-metrics',
 });
 
-// alternatively, use HONEYCOMB_API_KEY and OTEL_SERVICE_NAME and DEBUG environment variables
+// alternatively, use environment variables for
+// HONEYCOMB_API_KEY, OTEL_SERVICE_NAME, DEBUG, and HONEYCOMB_METRICS_DATASET
 // const sdk = new HoneycombSDK();
 
 const express = require('express');
@@ -24,6 +27,9 @@ app.get('/', (req, res) => {
   res.setHeader('Content-Type', 'text/plain');
   const sayHello = () => 'Hello world!';
   const tracer = trace.getTracer('hello-world-tracer');
+  const meter = metrics.getMeter('hello-world-meter');
+  const counter = meter.createCounter('sheep');
+  counter.add(1);
   // new context based on current, with key/values added to baggage
   const ctx = propagation.setBaggage(
     context.active(),

--- a/examples/hello-node-express/package-lock.json
+++ b/examples/hello-node-express/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@honeycombio/opentelemetry-node": "file:../../dist/src",
-        "@opentelemetry/auto-instrumentations-node": "^0.34.0",
+        "@opentelemetry/auto-instrumentations-node": "^0.35.0",
+        "@opentelemetry/sdk-metrics": "^1.8.0",
         "express": "^4.18.2"
       }
     },
@@ -104,9 +105,9 @@
       "link": true
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.2.0.tgz",
-      "integrity": "sha512-0nBr+VZNKm9tvNDZFstI3Pq1fCTEDK5OZTnVKNvBNAKgd0yIvmwsP4m61rEv7ZP+tOUjWJhROpxK5MsnlF911g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
+      "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -115,6 +116,7 @@
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.32.0.tgz",
       "integrity": "sha512-g1WLhpG8B6iuDyZJFRGsR+JKyZ94m5LEmY2f+duEJ9Xb4XRlLHrZvh6G34OH6GJ8iDHxfHb/sWjJ1ZpkI9yGMQ==",
+      "deprecated": "Please use @opentelemetry/api >= 1.3.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -123,52 +125,52 @@
       }
     },
     "node_modules/@opentelemetry/auto-instrumentations-node": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.34.0.tgz",
-      "integrity": "sha512-VfQZ47wdNKm7Lkp8ObthwyCXPfEumFP5xuuMdo+MH4Lry1fpu6LksCsu8cY0pJnBLr25020uC6UpBln0AVxXpA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.35.0.tgz",
+      "integrity": "sha512-qzPNSsus5cfZnteHMBAiJSl3LkuKmqOwxDKYLOAuJIcyFMsUZT1Z/00upI8OIESjHfeCDuYC3JI5TF/KhZpwCw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
-        "@opentelemetry/instrumentation-amqplib": "^0.31.0",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.33.1",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.9.3",
-        "@opentelemetry/instrumentation-bunyan": "^0.30.1",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.31.0",
-        "@opentelemetry/instrumentation-connect": "^0.30.1",
-        "@opentelemetry/instrumentation-dataloader": "^0.2.1",
-        "@opentelemetry/instrumentation-dns": "^0.30.1",
-        "@opentelemetry/instrumentation-express": "^0.31.3",
-        "@opentelemetry/instrumentation-fastify": "^0.30.1",
-        "@opentelemetry/instrumentation-fs": "^0.5.1",
-        "@opentelemetry/instrumentation-generic-pool": "^0.30.0",
-        "@opentelemetry/instrumentation-graphql": "^0.32.0",
-        "@opentelemetry/instrumentation-grpc": "^0.32.0",
-        "@opentelemetry/instrumentation-hapi": "^0.30.1",
-        "@opentelemetry/instrumentation-http": "^0.32.0",
-        "@opentelemetry/instrumentation-ioredis": "^0.32.2",
-        "@opentelemetry/instrumentation-knex": "^0.30.1",
-        "@opentelemetry/instrumentation-koa": "^0.33.0",
-        "@opentelemetry/instrumentation-lru-memoizer": "^0.31.0",
-        "@opentelemetry/instrumentation-memcached": "^0.30.1",
-        "@opentelemetry/instrumentation-mongodb": "^0.32.2",
-        "@opentelemetry/instrumentation-mongoose": "^0.31.1",
-        "@opentelemetry/instrumentation-mysql": "^0.31.2",
-        "@opentelemetry/instrumentation-mysql2": "^0.32.1",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.31.1",
-        "@opentelemetry/instrumentation-net": "^0.30.2",
-        "@opentelemetry/instrumentation-pg": "^0.32.0",
-        "@opentelemetry/instrumentation-pino": "^0.32.1",
-        "@opentelemetry/instrumentation-redis": "^0.33.1",
-        "@opentelemetry/instrumentation-redis-4": "^0.33.1",
-        "@opentelemetry/instrumentation-restify": "^0.30.1",
-        "@opentelemetry/instrumentation-router": "^0.31.0",
-        "@opentelemetry/instrumentation-tedious": "^0.4.1",
-        "@opentelemetry/instrumentation-winston": "^0.30.1"
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation-amqplib": "^0.32.0",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.34.0",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.10.0",
+        "@opentelemetry/instrumentation-bunyan": "^0.31.0",
+        "@opentelemetry/instrumentation-cassandra-driver": "^0.32.0",
+        "@opentelemetry/instrumentation-connect": "^0.31.0",
+        "@opentelemetry/instrumentation-dataloader": "^0.3.0",
+        "@opentelemetry/instrumentation-dns": "^0.31.0",
+        "@opentelemetry/instrumentation-express": "^0.32.0",
+        "@opentelemetry/instrumentation-fastify": "^0.31.0",
+        "@opentelemetry/instrumentation-fs": "^0.6.0",
+        "@opentelemetry/instrumentation-generic-pool": "^0.31.0",
+        "@opentelemetry/instrumentation-graphql": "^0.33.0",
+        "@opentelemetry/instrumentation-grpc": "^0.34.0",
+        "@opentelemetry/instrumentation-hapi": "^0.31.0",
+        "@opentelemetry/instrumentation-http": "^0.34.0",
+        "@opentelemetry/instrumentation-ioredis": "^0.33.0",
+        "@opentelemetry/instrumentation-knex": "^0.31.0",
+        "@opentelemetry/instrumentation-koa": "^0.34.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "^0.32.0",
+        "@opentelemetry/instrumentation-memcached": "^0.31.0",
+        "@opentelemetry/instrumentation-mongodb": "^0.33.0",
+        "@opentelemetry/instrumentation-mongoose": "^0.32.0",
+        "@opentelemetry/instrumentation-mysql": "^0.32.0",
+        "@opentelemetry/instrumentation-mysql2": "^0.33.0",
+        "@opentelemetry/instrumentation-nestjs-core": "^0.32.0",
+        "@opentelemetry/instrumentation-net": "^0.31.0",
+        "@opentelemetry/instrumentation-pg": "^0.33.0",
+        "@opentelemetry/instrumentation-pino": "^0.33.0",
+        "@opentelemetry/instrumentation-redis": "^0.34.0",
+        "@opentelemetry/instrumentation-redis-4": "^0.34.0",
+        "@opentelemetry/instrumentation-restify": "^0.31.0",
+        "@opentelemetry/instrumentation-router": "^0.32.0",
+        "@opentelemetry/instrumentation-tedious": "^0.5.0",
+        "@opentelemetry/instrumentation-winston": "^0.31.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/core": {
@@ -186,6 +188,57 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
+      "dependencies": {
+        "require-in-the-middle": "^5.0.3",
+        "semver": "^7.3.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.32.0.tgz",
+      "integrity": "sha512-/JkDnNNXHBrmesXS826E2z8c/EZoClO4S8ckQzbqdLd+m+n4u9Q9q/9ZV7WWlSAd7BSt3GJNbcjwdxeA7FobKw==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@types/amqplib": "^0.5.17"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-aws-lambda": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.34.0.tgz",
+      "integrity": "sha512-y/Tn+sFTssJaEb9cJOU3BTxR7ZrVg+6v0cgCO46SIPahhNrDq1kbQ2fYIdG/EVfwbfJyn80bfOQvfE3hNflmeA==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/propagator-aws-xray": "^1.1.1",
+        "@opentelemetry/resources": "^1.8.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@types/aws-lambda": "8.10.81"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-aws-lambda/node_modules/@opentelemetry/instrumentation": {
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.32.0.tgz",
       "integrity": "sha512-y6ADjHpkUz/v1nkyyYjsQa/zorhX+0qVGpFvXMcbjU4sHnBnC02c6wcc93sIgZfiQClIWo45TGku1KQxJ5UUbQ==",
@@ -202,95 +255,60 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-amqplib": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.31.0.tgz",
-      "integrity": "sha512-XkWgChRpvI2bNH1Y0CeB92qepzSxIklVBM8MvYnbmMisOzBFlqhe8LMs5szba/78qR2UJ9w7vcrf0HwEK8qERw==",
-      "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/amqplib": "^0.5.17"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.33.1.tgz",
-      "integrity": "sha512-bjiKVgIntf7USvrmkl8A0irdG3I5YT0QHnfTk8MQcCp1G4U7H/brDeijFtCTcC0GNjR4Me1VFCgkkZo/eyq/Ag==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
-        "@opentelemetry/propagator-aws-xray": "^1.1.1",
-        "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/aws-lambda": "8.10.81"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.9.3.tgz",
-      "integrity": "sha512-JM3Rg1jagBMIfhJd00NwLWvXLDZhf06izAeabhLwu5Tf8/R+LCVP4UebahCU8br/HZ91AMK+O+Wur41YeYsjNA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.10.0.tgz",
+      "integrity": "sha512-8LJfZjoca9Dn+U19mPGjtKGstUrCj5/cRithJCJxrab24Cyry4DnNqltTrXUGIE5Y6XNxX4VXQHiJC/EYyl/CQ==",
       "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
-        "@opentelemetry/propagation-utils": "^0.29.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/propagation-utils": "^0.29.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-bunyan": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.30.1.tgz",
-      "integrity": "sha512-IoOJ5wEQlUixfk5YyjKPBoc28nQwn7GuhBwsATKb5Bss2LXkXeWu4p/GxrDN4tPnrCMFtLlmeXhxbGsdx73hAQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.31.0.tgz",
+      "integrity": "sha512-yehA39p7olnrfBp4VDmOrK/vvMIvmT/8euimRRpQNa/bAPE7vQnbHokfOxsIXIKYqJdhEc9Rxc5pJ7StTrS7wA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@types/bunyan": "1.8.7"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.31.0.tgz",
-      "integrity": "sha512-YoS4djsixr6Po06d9M6IsWF7EcN7Dokwnfe28C7Xy//xHc0E8ENZTI9Ho/vS+hlvTUouFBYgk2oxHaK6Fq8AIw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.32.0.tgz",
+      "integrity": "sha512-5b68tqZDCRBFp8oQf7vN9RJY+UAfQyAxsrGiJBgGGK159nOIoHHBLjfM02A4rkmkPdJUNz3G02jkFbHFUN/vnw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.30.1.tgz",
-      "integrity": "sha512-holfuVSpNWuU/yaLugYLArWBwoWAcAGoHpfgNEM8qEGIlYDq1dWtsJvUVJ90YZmvN+vAJPfWOQnZ9jBcNudb4w==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.31.0.tgz",
+      "integrity": "sha512-7vzK3KQWjxY5yeTy+uqgclSxcS8qM8fnc2yO67EouHt6YNciJbL0pPKw1tGG6Yem/q5vr4qmFTFuYqjnD9Jq1Q==",
       "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/connect": "3.4.35"
       },
@@ -298,29 +316,29 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-dataloader": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.2.1.tgz",
-      "integrity": "sha512-Y53McRcXbDSNYChVxNZ0PZrEC+M4OkeTwTLwuKsZcJWcnf4iAZU4NsQFyRBCVDnsG4nyvuud6d1SHavuRigfzQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.3.0.tgz",
+      "integrity": "sha512-dV/EXnFrztisi3GXmv9WoweCiw5j02fPZwUKP5VzwqlJFHOy1x4U8qxzhkOYZF4nJFI4X70F2oHXDE1Ah0TRkg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0"
+        "@opentelemetry/instrumentation": "^0.34.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-dns": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.30.1.tgz",
-      "integrity": "sha512-IuSUGaTU1uvH7KGdFqjwdCsyD5NbFe43NcV1AnpGvyK1kS3p+5yB2ZLcwjglykXm8yg2rFM9ihzZxbqNY9b1NQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.31.0.tgz",
+      "integrity": "sha512-enaXHCdKPOm8eaRddw3ZA1DDU+7E7fGJs2EuhFi2xlzdyWs6luoycVZaJ2cPvJlNWJLrhBPtyGH6qbxoVi/5FQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "semver": "^7.3.2"
       },
@@ -328,16 +346,16 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.31.3.tgz",
-      "integrity": "sha512-+uta+Esj2r7oRXN2xLyI45JahbTCi07A6KpwvJZGKFaQg6nDBdWyfDdj5s1h2N13IsbFbcQqK4vidTeCcRuR8Q==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.32.0.tgz",
+      "integrity": "sha512-t2QOKwaZXUXQSJn4G90THpOyxyNBUyK0B059PUQpOqc/uybUo0SI8edfVlYRlcfHadG+S0fnU8QvnldmZ8AJqA==",
       "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/express": "4.17.13"
       },
@@ -345,103 +363,93 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.30.1.tgz",
-      "integrity": "sha512-JjUNLlIOp/uNFF7pkLa+VEerItdqG84rM0rxZ0AWcAaS5MX0ycfnhsfIzCKwBAb8WijlkzU7vGAhNRJbhAhrGg==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.31.0.tgz",
+      "integrity": "sha512-HLKoG3ZY8hgK/xHwTy4CD/ybAc+cRkjal4AEE978vVeV8ArUfiN7SwQu5P97kW03lIpzJ8IDtk8UewpNe8VWyA==",
       "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-fs": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.5.1.tgz",
-      "integrity": "sha512-aGG/E6Yh74PuenV5YsMTjB8FN8+l4g0Fu9vc9mEvyR9s72nzk63CO5+BqpyKi8N0JDr597/XRo82PLNaq4NpXQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.6.0.tgz",
+      "integrity": "sha512-TBnEW1wthnfcYA65VJqbFtDpKqDnwTqqJ9R1tQ4qU3qrxhRhN6mMOok6XaCbT+ddCerI7fvWHtm5jYBJ00XQmw==",
       "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.30.0.tgz",
-      "integrity": "sha512-Q9VYMok7Qchlf+Q4s5TPCpmWvbxg4JMKZgkwTj25ZBGUlWWTfk1/oCctcQHok1Yvdvctczzr1DGrFw08cQDdCA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.31.0.tgz",
+      "integrity": "sha512-XbF07I0uSfGbPHqjx86LIQWllY0lfIXM0yIpFMxqiW6OY7xRdk6GWcvKmUq/eU+3ZYrLb2nn9EqUpWDMWDnejg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/generic-pool": "^3.1.9"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.32.0.tgz",
-      "integrity": "sha512-5GLoivx+h0YCMDEkFz0bHZCOlwc8QN1DBHN2kf7G1w/aJomB41vpT/pgfXk+SfVMT7kEKY4OIp4pnrkAipA22w==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.33.0.tgz",
+      "integrity": "sha512-d3Qv847LI5JLJF3iR9+86V7K/+nUqVkNu2XJ1L1/4Ze5sih1R+722tx7IrS7UEDkkoNI0E0m74Yg9pJ0kwXMTQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0"
+        "@opentelemetry/instrumentation": "^0.34.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0",
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.32.0.tgz",
-      "integrity": "sha512-Az6wdkPx/Mi26lT9LKFV6GhCA9prwQFPz5eCNSExTnSP49YhQ7XCjzPd2POPeLKt84ICitrBMdE1mj0zbPdLAQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.34.0.tgz",
+      "integrity": "sha512-IqwWq5d3Jiah0eSm1IH6K32rYKe4nnMKkm7qV6ISwWhFFtUPfuOatUKAttmuvipvPCuxiiIS2P/zbmytkwmFVg==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.32.0",
-        "@opentelemetry/instrumentation": "0.32.0",
-        "@opentelemetry/semantic-conventions": "1.6.0"
+        "@opentelemetry/instrumentation": "0.34.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
-      "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.30.1.tgz",
-      "integrity": "sha512-lzvru/D/C/izAtYm1WE9qm3ch1xFnQ2yVVSXIlDWvJ0RGmTAtgO+zl1i6eZT3FUkO4tOBga8RADwDhtv/fervg==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.31.0.tgz",
+      "integrity": "sha512-+VPnZFRfXeZpF0WuaCym9mPkjQyJa8t0S/qw7v5OWs6w64VLyT7mFLh6dChYoivwx8N0p+TaO/l/Bb+e4y/neg==",
       "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/hapi__hapi": "20.0.9"
       },
@@ -449,54 +457,32 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.32.0.tgz",
-      "integrity": "sha512-EbNdJl6IjouphbxPVGV8/utiqB2DhveyH5TD6vxjc2OXlQ3A/mKg3fYSSWB+rYQBuuli+jWQfBJe2ntOFZtTMw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.34.0.tgz",
+      "integrity": "sha512-sZxpYOggRIFwdcdy1wWBGG8fwiuWWK4j3qv/rdqTwcPvrVT4iSCoPNDMZYxOcxSEP1fybq28SK43e+IKwxVElQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.6.0",
-        "@opentelemetry/instrumentation": "0.32.0",
-        "@opentelemetry/semantic-conventions": "1.6.0",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/instrumentation": "0.34.0",
+        "@opentelemetry/semantic-conventions": "1.8.0",
         "semver": "^7.3.5"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-MsEhsyCTfYme6frK8/AqEWwbS9SB3Ta5bjgz4jPQJjL7ijUM3JiLVvqh/kHo1UlUjbUbLmGG7jA5Nw4d7SMcLQ==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.6.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
-      "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ==",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.32.2.tgz",
-      "integrity": "sha512-o24urJ3/Q/EC6CuDYseb2+Wts7LA+GljD6e+zDhSfILmm8yYe1cb3Hv45ZEA/qFv9DpYqqIzENSAaXi7/F1j8g==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.33.0.tgz",
+      "integrity": "sha512-RhsR3PFdUNiNGnGPVoNpjrsoNWxKrdyAqSOaodE1uoVsJrVBIEKNCD4P82ccTjCuQHsa8ni0/DCt4Cxq7oNG3g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/ioredis": "4.26.6"
       },
@@ -504,31 +490,31 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.30.1.tgz",
-      "integrity": "sha512-fvB5gLFv54FfEdtIft03OoxNxijFxhAn1ZEtVHgS43TM7dAIu++LdBKG+dhIqV0woA4fiGtNDetiTYJqJKfLeg==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.31.0.tgz",
+      "integrity": "sha512-BqEFTckHDYgD9sPNhdkoL5BHbGevFoPK2XTKBTZah2DR4rD48G8ntsE8K6kt17lA1Q1jgdqe4U690UxGC6/m3g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-koa": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.33.0.tgz",
-      "integrity": "sha512-b0+1polkk/q2xS+Hla4YG9UbRZyOQoUkm2/ybEM7qLeXzq98m6GL4ss5mj6mJJSU7r6iWxF8Nx5t0p2KZd70UA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.34.0.tgz",
+      "integrity": "sha512-+ZLABLbe08U6Xg8Eyu0AJCjchk9Kpah8lUEAUhaNdY2M5RdEqlm4LkvlCdmq425KzsrTX0AeWaCfcvGqFr4+lw==",
       "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/koa": "2.13.4",
         "@types/koa__router": "8.0.7"
@@ -537,29 +523,29 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.31.0.tgz",
-      "integrity": "sha512-eAUwYtTK7Tmb/ruXSBB5wW4lXW8HsmWmbmFDL8rmOo2eCCKTZocm9Mk79scKminA59Mb5vfZjn7r21KRlYFCSQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.32.0.tgz",
+      "integrity": "sha512-wXTfawB+RBnPH2xF5S9vOEMXYHY15oRKhV94dWb61k/dMqlGgfcFug6/qY4vkZgm58GhNbFoF5RWNNUpU4LOAQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0"
+        "@opentelemetry/instrumentation": "^0.34.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-memcached": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.30.1.tgz",
-      "integrity": "sha512-DBDhMeigjp3yr37CokJWpPqj4ME6LT8i2Ft8yz6Ole3yLjcrmAKuVvHl2UM7E8h2JmSd/lwhBCBCO2rH4B+UrQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.31.0.tgz",
+      "integrity": "sha512-wkoZQ6TyHWuaHTmV/MSIqJzFyEnjWj6hdRftX6eJUv1xalYjrxDZW6gFiByRdlVKupuksIW3/ntvozyLhzbJqQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/memcached": "^2.2.6"
       },
@@ -567,46 +553,46 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.32.2.tgz",
-      "integrity": "sha512-C3OWsc1Fan+xl+ly0C8VxiICb30xevoG82Ytx+4LOemiZc37WPcTdJMrXi2MyOtRc7kqN6xYf2zbU/n+y8BsUQ==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.33.0.tgz",
+      "integrity": "sha512-bjRF55grOFRn5XQxm1yDL56FD9UVvmIcBDSsgA0dbUr3VOUu3sN7o34t2uDx7EpnfwhMeAvOBO1wbWXdHBzapg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongoose": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.31.1.tgz",
-      "integrity": "sha512-g7dMXFUGjRioH3HfSDjgQi/YGdiWaLvLdux0TR1nSgrF3PGHk2djL2Nv4hxibz396QyEEtn9pyXvIwGLNHXGKw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.32.0.tgz",
+      "integrity": "sha512-Br8x76u1xsMiU4nwioYX8NwIBxl4Kt0dTDrZvqtwLkmr7gmHoxApN17QquQcEcuTfonQ4NXIB3A/k1BiPAaq/g==",
       "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.31.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.31.2.tgz",
-      "integrity": "sha512-YcJ3YeQ3tisHWWpUfD156Koc+LfktOzJD4tAFLaqoKTcvu5gl6VfKJ3scoTOtVxxvFBAK66MvMMXMHSaCv9b5w==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.32.0.tgz",
+      "integrity": "sha512-9BGbc0wiNokflUKmI3WEOnmCqp9QffcnrIoIs2cjqQekZGAzSmL7tyyL3SoW/qXWOUP8FM+OuEomklujNOZYbg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.19"
       },
@@ -614,60 +600,60 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.32.1.tgz",
-      "integrity": "sha512-tNh393lu/n1FEIvaeHo9VodiFYak8TKyVDjaYhWaBM5Oy4UbMUmCSo52H9Mbbi/c1Y24h8V2ppu04amQvtj9gg==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.33.0.tgz",
+      "integrity": "sha512-DVWkr/WkALmIdtLoiVp/vgZVOXUCFvnlKOEz+LOQMHOktm0FLhdHRjX7jJhtVtEO7DdZQRnfpUYv8zP37gMawQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.31.1.tgz",
-      "integrity": "sha512-XWA91MFtVmdmcbvq5oFFXtot2GrKbWrR2R9gPVXmsOnW/4fnQg7id9kMFta77/5q16BYLVfZ9VLblwjdTdDVYw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.32.0.tgz",
+      "integrity": "sha512-kpzegHf1tNqtZhC+BCM/B9n3/e+vBYYYGZK+HUgiL/lHUoUf3Lsj6869eckSgucrScLjDGNBuo5j8JAkdNJ5zw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-net": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.30.2.tgz",
-      "integrity": "sha512-1k5oY/MT3q7v1t0gK5D0C/xF24FMy8YewxPuTH4b4DRFILxo5MriRZ4QWPM4LmFUxkqJsHrt4mW3LPVejiYYmA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.31.0.tgz",
+      "integrity": "sha512-uzgI0AMZWYqN/w8oQ3EwSpFKnZ+yMVbzoRczh8pVZgWR8Xw35/h9GfgrOO2Sb9/4nf75bwO83hjRkW4KfsEE7w==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.32.0.tgz",
-      "integrity": "sha512-ZY2zcJOwCwSbY8a0wAwUgQXhOMIOaTGSWhHWkDJV92PY1T5E4r0B0kjF9EsBkT8cFqHEgVxt1ZeodfD3Wilh3A==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.33.0.tgz",
+      "integrity": "sha512-RYs4xsGkIKM5cw/3WPRKxjDyLd1DXhwYaNugJlbozDzkToZ1SRzd8I2qAJ2nTTKHtFrWYCqZILPXnRguZNHmnA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.3"
@@ -676,29 +662,29 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-pino": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.32.1.tgz",
-      "integrity": "sha512-GfMQ2U8/37NK/7YDF1sqI8vQkxVwXVfgBkFh0ZXI387nkTYvzp2EqBsGSJ9c1aWPeDPI4sqpFtkZosu1TrfXnA==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.33.0.tgz",
+      "integrity": "sha512-2ZU6ri1/90UpLIZGIeF48BG58mZEtHBUgxYPj08J+HbatHkLg5RQtIy0Q9P9UbAAq+2+Izh2RDm5K1T5OVGkMg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0"
+        "@opentelemetry/instrumentation": "^0.34.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.33.1.tgz",
-      "integrity": "sha512-17xuGpIXo1ugQo51xPtzDuE24qc95MQuEdWTFXESOgFWd+FshpS9+TF4RmegK6hhZ81ekkwwGNK+fYFmWKnCXw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.34.0.tgz",
+      "integrity": "sha512-fUrU3Ekhxu6bcnurP/rfhZJNxQV9qUP2vQSQSRwPiPZs+s3UKuY19rQEFCST10jF66rQrqB32VwnGqeQyZbHlw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/redis": "2.8.31"
       },
@@ -706,61 +692,61 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis-4": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.33.1.tgz",
-      "integrity": "sha512-LoJRsiDKSFZ0cU9sicHfZqqpaunCwI7h2CWZvIrenOdXdg8TLpeXumzEiFbaCkZ80fzxsM6IqEzCtiVo4+n93w==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.34.0.tgz",
+      "integrity": "sha512-b3joRK8+aSszaznUoL8vtZrwreN/CJY0VZbmE3HE8IUvOc6W0QRvOl7fDAJ2z56lDT0f7cZSV05gpvslXgZeWg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-restify": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.30.1.tgz",
-      "integrity": "sha512-5ss8mqGhtZIQ38C1bOSWb1Pu5QgRejLsdxTR94IYsLhSkBD4boK7EhgwxXpYz80FCqDe+3852bTS65e3PFU8mw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.31.0.tgz",
+      "integrity": "sha512-b0AWFZ9+tm4Iaydt1AquBpsQty+Uv1YQ3C9Jb4/JTknWDWW63tb8FoCcALMPYDulvOgH+PPDvtvZY0Q0Imbstg==",
       "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-router": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.31.0.tgz",
-      "integrity": "sha512-5sYa7s7vKGcBUppT5ejRlo6OXuFTaVAjr7ucLcSh45LuYDqTFZRMkhE4wh4DQ7TnrAenS1Nxqv/6/hy0rgyxPA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.32.0.tgz",
+      "integrity": "sha512-s7RywETzH4FW+8yzPqbBYh5BdtILjM9cjhofucVXDcKY3tNSJA1gGBTCDOK49+ec9zyo1e+nchiYaeS9IW8U/A==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.4.1.tgz",
-      "integrity": "sha512-1vDzO5JfhyZQ60X52gT3ZSsTVpc24SGmEmjhfidQgGHla2lpqVwsfouwTNCkgWZ1IkO4nA127+WV9+ova9LnTw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.5.0.tgz",
+      "integrity": "sha512-PaaB56cggwg69JPTi3CYR0JnXV+hjBFAnkhKKwIKeaiHew7txOfPZo8S1cEW058jOPFySV+Qg8ZkGApXkvp5zg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/tedious": "^4.0.6"
       },
@@ -768,27 +754,27 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation-winston": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.30.1.tgz",
-      "integrity": "sha512-qONu+aYObIvFVkW/mq4EK4a7kspMvouHnZfQUZpywHnY/0wk9YlaNsnRggNmKb+Ig5ThxxB+sldFyZrlKdoncQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.31.0.tgz",
+      "integrity": "sha512-+19vD2v9wWuUP4Hz0dHcpeT5/5Ke0dtIeZ+zCFXJA4lLLR9QeKMN0ORFlbpAOBwKjjuaBHXnMAwuoMSdOUxCKw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0"
+        "@opentelemetry/instrumentation": "^0.34.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/propagation-utils": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.29.0.tgz",
-      "integrity": "sha512-9KyRHd3/v+DhcoGDbkbSrxQlDRhTcGwiXUvgjjWkCmmzQ4Z8G5WHgXxoGBe6crcamGk9X+SyKtePkq9dYG2eaA==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.29.1.tgz",
+      "integrity": "sha512-sSlkke2RrUuWcbhsRUxbwn6G9XtPa1b8zUoudvxxwvs7nCPE2pQRy32JyqT7CbuWf6gQPK/R1u54T79c93oyGQ==",
       "engines": {
         "node": ">=14"
       },
@@ -823,6 +809,22 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.4.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.8.0.tgz",
+      "integrity": "sha512-+KYb+uj0vHhl8xzJO+oChS4oP1e+/2Wl3SXoHoIdcEjd1TQfDV+lxOm4oqxWq6wykXvI35/JHyejxSoT+qxGmg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/resources": "1.8.0",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.4.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -874,9 +876,9 @@
       "integrity": "sha512-C1rFKGVZ8KwqhwBOYlpoybTSRtxu2433ea6JaO3amc6ubEe08yQoFsPa9aU9YqvX7ppeZ25CnCtC4AH9mhtxsQ=="
     },
     "node_modules/@types/bluebird": {
-      "version": "3.5.37",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.37.tgz",
-      "integrity": "sha512-g2qEd+zkfkTEudA2SrMAeAvY7CrFqtbsLILm2dT2VIeKTqMqVzcdfURlvu6FU3srRgbmXN1Srm94pg34EIehww=="
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.38.tgz",
+      "integrity": "sha512-yR/Kxc0dd4FfwtEoLZMoqJbM/VE/W7hXn/MIjb+axcwag0iFmSPK7OBUZq1YWLynJUoWQkfUrI7T0HDqGApNSg=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -1065,9 +1067,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+      "version": "18.11.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.15.tgz",
+      "integrity": "sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw=="
     },
     "node_modules/@types/pg": {
       "version": "8.6.1",
@@ -1357,15 +1359,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/graphql": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-      "peer": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1449,6 +1442,11 @@
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1991,9 +1989,9 @@
       "version": "file:../../dist/src"
     },
     "@opentelemetry/api": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.2.0.tgz",
-      "integrity": "sha512-0nBr+VZNKm9tvNDZFstI3Pq1fCTEDK5OZTnVKNvBNAKgd0yIvmwsP4m61rEv7ZP+tOUjWJhROpxK5MsnlF911g=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
+      "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ=="
     },
     "@opentelemetry/api-metrics": {
       "version": "0.32.0",
@@ -2004,46 +2002,46 @@
       }
     },
     "@opentelemetry/auto-instrumentations-node": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.34.0.tgz",
-      "integrity": "sha512-VfQZ47wdNKm7Lkp8ObthwyCXPfEumFP5xuuMdo+MH4Lry1fpu6LksCsu8cY0pJnBLr25020uC6UpBln0AVxXpA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.35.0.tgz",
+      "integrity": "sha512-qzPNSsus5cfZnteHMBAiJSl3LkuKmqOwxDKYLOAuJIcyFMsUZT1Z/00upI8OIESjHfeCDuYC3JI5TF/KhZpwCw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
-        "@opentelemetry/instrumentation-amqplib": "^0.31.0",
-        "@opentelemetry/instrumentation-aws-lambda": "^0.33.1",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.9.3",
-        "@opentelemetry/instrumentation-bunyan": "^0.30.1",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.31.0",
-        "@opentelemetry/instrumentation-connect": "^0.30.1",
-        "@opentelemetry/instrumentation-dataloader": "^0.2.1",
-        "@opentelemetry/instrumentation-dns": "^0.30.1",
-        "@opentelemetry/instrumentation-express": "^0.31.3",
-        "@opentelemetry/instrumentation-fastify": "^0.30.1",
-        "@opentelemetry/instrumentation-fs": "^0.5.1",
-        "@opentelemetry/instrumentation-generic-pool": "^0.30.0",
-        "@opentelemetry/instrumentation-graphql": "^0.32.0",
-        "@opentelemetry/instrumentation-grpc": "^0.32.0",
-        "@opentelemetry/instrumentation-hapi": "^0.30.1",
-        "@opentelemetry/instrumentation-http": "^0.32.0",
-        "@opentelemetry/instrumentation-ioredis": "^0.32.2",
-        "@opentelemetry/instrumentation-knex": "^0.30.1",
-        "@opentelemetry/instrumentation-koa": "^0.33.0",
-        "@opentelemetry/instrumentation-lru-memoizer": "^0.31.0",
-        "@opentelemetry/instrumentation-memcached": "^0.30.1",
-        "@opentelemetry/instrumentation-mongodb": "^0.32.2",
-        "@opentelemetry/instrumentation-mongoose": "^0.31.1",
-        "@opentelemetry/instrumentation-mysql": "^0.31.2",
-        "@opentelemetry/instrumentation-mysql2": "^0.32.1",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.31.1",
-        "@opentelemetry/instrumentation-net": "^0.30.2",
-        "@opentelemetry/instrumentation-pg": "^0.32.0",
-        "@opentelemetry/instrumentation-pino": "^0.32.1",
-        "@opentelemetry/instrumentation-redis": "^0.33.1",
-        "@opentelemetry/instrumentation-redis-4": "^0.33.1",
-        "@opentelemetry/instrumentation-restify": "^0.30.1",
-        "@opentelemetry/instrumentation-router": "^0.31.0",
-        "@opentelemetry/instrumentation-tedious": "^0.4.1",
-        "@opentelemetry/instrumentation-winston": "^0.30.1"
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation-amqplib": "^0.32.0",
+        "@opentelemetry/instrumentation-aws-lambda": "^0.34.0",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.10.0",
+        "@opentelemetry/instrumentation-bunyan": "^0.31.0",
+        "@opentelemetry/instrumentation-cassandra-driver": "^0.32.0",
+        "@opentelemetry/instrumentation-connect": "^0.31.0",
+        "@opentelemetry/instrumentation-dataloader": "^0.3.0",
+        "@opentelemetry/instrumentation-dns": "^0.31.0",
+        "@opentelemetry/instrumentation-express": "^0.32.0",
+        "@opentelemetry/instrumentation-fastify": "^0.31.0",
+        "@opentelemetry/instrumentation-fs": "^0.6.0",
+        "@opentelemetry/instrumentation-generic-pool": "^0.31.0",
+        "@opentelemetry/instrumentation-graphql": "^0.33.0",
+        "@opentelemetry/instrumentation-grpc": "^0.34.0",
+        "@opentelemetry/instrumentation-hapi": "^0.31.0",
+        "@opentelemetry/instrumentation-http": "^0.34.0",
+        "@opentelemetry/instrumentation-ioredis": "^0.33.0",
+        "@opentelemetry/instrumentation-knex": "^0.31.0",
+        "@opentelemetry/instrumentation-koa": "^0.34.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "^0.32.0",
+        "@opentelemetry/instrumentation-memcached": "^0.31.0",
+        "@opentelemetry/instrumentation-mongodb": "^0.33.0",
+        "@opentelemetry/instrumentation-mongoose": "^0.32.0",
+        "@opentelemetry/instrumentation-mysql": "^0.32.0",
+        "@opentelemetry/instrumentation-mysql2": "^0.33.0",
+        "@opentelemetry/instrumentation-nestjs-core": "^0.32.0",
+        "@opentelemetry/instrumentation-net": "^0.31.0",
+        "@opentelemetry/instrumentation-pg": "^0.33.0",
+        "@opentelemetry/instrumentation-pino": "^0.33.0",
+        "@opentelemetry/instrumentation-redis": "^0.34.0",
+        "@opentelemetry/instrumentation-redis-4": "^0.34.0",
+        "@opentelemetry/instrumentation-restify": "^0.31.0",
+        "@opentelemetry/instrumentation-router": "^0.32.0",
+        "@opentelemetry/instrumentation-tedious": "^0.5.0",
+        "@opentelemetry/instrumentation-winston": "^0.31.0"
       }
     },
     "@opentelemetry/core": {
@@ -2055,384 +2053,373 @@
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.32.0.tgz",
-      "integrity": "sha512-y6ADjHpkUz/v1nkyyYjsQa/zorhX+0qVGpFvXMcbjU4sHnBnC02c6wcc93sIgZfiQClIWo45TGku1KQxJ5UUbQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.32.0",
         "require-in-the-middle": "^5.0.3",
         "semver": "^7.3.2",
         "shimmer": "^1.2.1"
       }
     },
     "@opentelemetry/instrumentation-amqplib": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.31.0.tgz",
-      "integrity": "sha512-XkWgChRpvI2bNH1Y0CeB92qepzSxIklVBM8MvYnbmMisOzBFlqhe8LMs5szba/78qR2UJ9w7vcrf0HwEK8qERw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.32.0.tgz",
+      "integrity": "sha512-/JkDnNNXHBrmesXS826E2z8c/EZoClO4S8ckQzbqdLd+m+n4u9Q9q/9ZV7WWlSAd7BSt3GJNbcjwdxeA7FobKw==",
       "requires": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/amqplib": "^0.5.17"
       }
     },
     "@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.33.1.tgz",
-      "integrity": "sha512-bjiKVgIntf7USvrmkl8A0irdG3I5YT0QHnfTk8MQcCp1G4U7H/brDeijFtCTcC0GNjR4Me1VFCgkkZo/eyq/Ag==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.34.0.tgz",
+      "integrity": "sha512-y/Tn+sFTssJaEb9cJOU3BTxR7ZrVg+6v0cgCO46SIPahhNrDq1kbQ2fYIdG/EVfwbfJyn80bfOQvfE3hNflmeA==",
       "requires": {
         "@opentelemetry/instrumentation": "^0.32.0",
         "@opentelemetry/propagator-aws-xray": "^1.1.1",
-        "@opentelemetry/resources": "^1.0.0",
+        "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/aws-lambda": "8.10.81"
+      },
+      "dependencies": {
+        "@opentelemetry/instrumentation": {
+          "version": "0.32.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.32.0.tgz",
+          "integrity": "sha512-y6ADjHpkUz/v1nkyyYjsQa/zorhX+0qVGpFvXMcbjU4sHnBnC02c6wcc93sIgZfiQClIWo45TGku1KQxJ5UUbQ==",
+          "requires": {
+            "@opentelemetry/api-metrics": "0.32.0",
+            "require-in-the-middle": "^5.0.3",
+            "semver": "^7.3.2",
+            "shimmer": "^1.2.1"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.9.3.tgz",
-      "integrity": "sha512-JM3Rg1jagBMIfhJd00NwLWvXLDZhf06izAeabhLwu5Tf8/R+LCVP4UebahCU8br/HZ91AMK+O+Wur41YeYsjNA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.10.0.tgz",
+      "integrity": "sha512-8LJfZjoca9Dn+U19mPGjtKGstUrCj5/cRithJCJxrab24Cyry4DnNqltTrXUGIE5Y6XNxX4VXQHiJC/EYyl/CQ==",
       "requires": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
-        "@opentelemetry/propagation-utils": "^0.29.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/propagation-utils": "^0.29.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-bunyan": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.30.1.tgz",
-      "integrity": "sha512-IoOJ5wEQlUixfk5YyjKPBoc28nQwn7GuhBwsATKb5Bss2LXkXeWu4p/GxrDN4tPnrCMFtLlmeXhxbGsdx73hAQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.31.0.tgz",
+      "integrity": "sha512-yehA39p7olnrfBp4VDmOrK/vvMIvmT/8euimRRpQNa/bAPE7vQnbHokfOxsIXIKYqJdhEc9Rxc5pJ7StTrS7wA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@types/bunyan": "1.8.7"
       }
     },
     "@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.31.0.tgz",
-      "integrity": "sha512-YoS4djsixr6Po06d9M6IsWF7EcN7Dokwnfe28C7Xy//xHc0E8ENZTI9Ho/vS+hlvTUouFBYgk2oxHaK6Fq8AIw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.32.0.tgz",
+      "integrity": "sha512-5b68tqZDCRBFp8oQf7vN9RJY+UAfQyAxsrGiJBgGGK159nOIoHHBLjfM02A4rkmkPdJUNz3G02jkFbHFUN/vnw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-connect": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.30.1.tgz",
-      "integrity": "sha512-holfuVSpNWuU/yaLugYLArWBwoWAcAGoHpfgNEM8qEGIlYDq1dWtsJvUVJ90YZmvN+vAJPfWOQnZ9jBcNudb4w==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.31.0.tgz",
+      "integrity": "sha512-7vzK3KQWjxY5yeTy+uqgclSxcS8qM8fnc2yO67EouHt6YNciJbL0pPKw1tGG6Yem/q5vr4qmFTFuYqjnD9Jq1Q==",
       "requires": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/connect": "3.4.35"
       }
     },
     "@opentelemetry/instrumentation-dataloader": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.2.1.tgz",
-      "integrity": "sha512-Y53McRcXbDSNYChVxNZ0PZrEC+M4OkeTwTLwuKsZcJWcnf4iAZU4NsQFyRBCVDnsG4nyvuud6d1SHavuRigfzQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.3.0.tgz",
+      "integrity": "sha512-dV/EXnFrztisi3GXmv9WoweCiw5j02fPZwUKP5VzwqlJFHOy1x4U8qxzhkOYZF4nJFI4X70F2oHXDE1Ah0TRkg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0"
+        "@opentelemetry/instrumentation": "^0.34.0"
       }
     },
     "@opentelemetry/instrumentation-dns": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.30.1.tgz",
-      "integrity": "sha512-IuSUGaTU1uvH7KGdFqjwdCsyD5NbFe43NcV1AnpGvyK1kS3p+5yB2ZLcwjglykXm8yg2rFM9ihzZxbqNY9b1NQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.31.0.tgz",
+      "integrity": "sha512-enaXHCdKPOm8eaRddw3ZA1DDU+7E7fGJs2EuhFi2xlzdyWs6luoycVZaJ2cPvJlNWJLrhBPtyGH6qbxoVi/5FQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "semver": "^7.3.2"
       }
     },
     "@opentelemetry/instrumentation-express": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.31.3.tgz",
-      "integrity": "sha512-+uta+Esj2r7oRXN2xLyI45JahbTCi07A6KpwvJZGKFaQg6nDBdWyfDdj5s1h2N13IsbFbcQqK4vidTeCcRuR8Q==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.32.0.tgz",
+      "integrity": "sha512-t2QOKwaZXUXQSJn4G90THpOyxyNBUyK0B059PUQpOqc/uybUo0SI8edfVlYRlcfHadG+S0fnU8QvnldmZ8AJqA==",
       "requires": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/express": "4.17.13"
       }
     },
     "@opentelemetry/instrumentation-fastify": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.30.1.tgz",
-      "integrity": "sha512-JjUNLlIOp/uNFF7pkLa+VEerItdqG84rM0rxZ0AWcAaS5MX0ycfnhsfIzCKwBAb8WijlkzU7vGAhNRJbhAhrGg==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.31.0.tgz",
+      "integrity": "sha512-HLKoG3ZY8hgK/xHwTy4CD/ybAc+cRkjal4AEE978vVeV8ArUfiN7SwQu5P97kW03lIpzJ8IDtk8UewpNe8VWyA==",
       "requires": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-fs": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.5.1.tgz",
-      "integrity": "sha512-aGG/E6Yh74PuenV5YsMTjB8FN8+l4g0Fu9vc9mEvyR9s72nzk63CO5+BqpyKi8N0JDr597/XRo82PLNaq4NpXQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.6.0.tgz",
+      "integrity": "sha512-TBnEW1wthnfcYA65VJqbFtDpKqDnwTqqJ9R1tQ4qU3qrxhRhN6mMOok6XaCbT+ddCerI7fvWHtm5jYBJ00XQmw==",
       "requires": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.30.0.tgz",
-      "integrity": "sha512-Q9VYMok7Qchlf+Q4s5TPCpmWvbxg4JMKZgkwTj25ZBGUlWWTfk1/oCctcQHok1Yvdvctczzr1DGrFw08cQDdCA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.31.0.tgz",
+      "integrity": "sha512-XbF07I0uSfGbPHqjx86LIQWllY0lfIXM0yIpFMxqiW6OY7xRdk6GWcvKmUq/eU+3ZYrLb2nn9EqUpWDMWDnejg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/generic-pool": "^3.1.9"
       }
     },
     "@opentelemetry/instrumentation-graphql": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.32.0.tgz",
-      "integrity": "sha512-5GLoivx+h0YCMDEkFz0bHZCOlwc8QN1DBHN2kf7G1w/aJomB41vpT/pgfXk+SfVMT7kEKY4OIp4pnrkAipA22w==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.33.0.tgz",
+      "integrity": "sha512-d3Qv847LI5JLJF3iR9+86V7K/+nUqVkNu2XJ1L1/4Ze5sih1R+722tx7IrS7UEDkkoNI0E0m74Yg9pJ0kwXMTQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0"
+        "@opentelemetry/instrumentation": "^0.34.0"
       }
     },
     "@opentelemetry/instrumentation-grpc": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.32.0.tgz",
-      "integrity": "sha512-Az6wdkPx/Mi26lT9LKFV6GhCA9prwQFPz5eCNSExTnSP49YhQ7XCjzPd2POPeLKt84ICitrBMdE1mj0zbPdLAQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.34.0.tgz",
+      "integrity": "sha512-IqwWq5d3Jiah0eSm1IH6K32rYKe4nnMKkm7qV6ISwWhFFtUPfuOatUKAttmuvipvPCuxiiIS2P/zbmytkwmFVg==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.32.0",
-        "@opentelemetry/instrumentation": "0.32.0",
-        "@opentelemetry/semantic-conventions": "1.6.0"
-      },
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
-          "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ=="
-        }
+        "@opentelemetry/instrumentation": "0.34.0",
+        "@opentelemetry/semantic-conventions": "1.8.0"
       }
     },
     "@opentelemetry/instrumentation-hapi": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.30.1.tgz",
-      "integrity": "sha512-lzvru/D/C/izAtYm1WE9qm3ch1xFnQ2yVVSXIlDWvJ0RGmTAtgO+zl1i6eZT3FUkO4tOBga8RADwDhtv/fervg==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.31.0.tgz",
+      "integrity": "sha512-+VPnZFRfXeZpF0WuaCym9mPkjQyJa8t0S/qw7v5OWs6w64VLyT7mFLh6dChYoivwx8N0p+TaO/l/Bb+e4y/neg==",
       "requires": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/hapi__hapi": "20.0.9"
       }
     },
     "@opentelemetry/instrumentation-http": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.32.0.tgz",
-      "integrity": "sha512-EbNdJl6IjouphbxPVGV8/utiqB2DhveyH5TD6vxjc2OXlQ3A/mKg3fYSSWB+rYQBuuli+jWQfBJe2ntOFZtTMw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.34.0.tgz",
+      "integrity": "sha512-sZxpYOggRIFwdcdy1wWBGG8fwiuWWK4j3qv/rdqTwcPvrVT4iSCoPNDMZYxOcxSEP1fybq28SK43e+IKwxVElQ==",
       "requires": {
-        "@opentelemetry/core": "1.6.0",
-        "@opentelemetry/instrumentation": "0.32.0",
-        "@opentelemetry/semantic-conventions": "1.6.0",
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/instrumentation": "0.34.0",
+        "@opentelemetry/semantic-conventions": "1.8.0",
         "semver": "^7.3.5"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.6.0.tgz",
-          "integrity": "sha512-MsEhsyCTfYme6frK8/AqEWwbS9SB3Ta5bjgz4jPQJjL7ijUM3JiLVvqh/kHo1UlUjbUbLmGG7jA5Nw4d7SMcLQ==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.6.0"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz",
-          "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ=="
-        }
       }
     },
     "@opentelemetry/instrumentation-ioredis": {
-      "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.32.2.tgz",
-      "integrity": "sha512-o24urJ3/Q/EC6CuDYseb2+Wts7LA+GljD6e+zDhSfILmm8yYe1cb3Hv45ZEA/qFv9DpYqqIzENSAaXi7/F1j8g==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.33.0.tgz",
+      "integrity": "sha512-RhsR3PFdUNiNGnGPVoNpjrsoNWxKrdyAqSOaodE1uoVsJrVBIEKNCD4P82ccTjCuQHsa8ni0/DCt4Cxq7oNG3g==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/ioredis": "4.26.6"
       }
     },
     "@opentelemetry/instrumentation-knex": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.30.1.tgz",
-      "integrity": "sha512-fvB5gLFv54FfEdtIft03OoxNxijFxhAn1ZEtVHgS43TM7dAIu++LdBKG+dhIqV0woA4fiGtNDetiTYJqJKfLeg==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.31.0.tgz",
+      "integrity": "sha512-BqEFTckHDYgD9sPNhdkoL5BHbGevFoPK2XTKBTZah2DR4rD48G8ntsE8K6kt17lA1Q1jgdqe4U690UxGC6/m3g==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-koa": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.33.0.tgz",
-      "integrity": "sha512-b0+1polkk/q2xS+Hla4YG9UbRZyOQoUkm2/ybEM7qLeXzq98m6GL4ss5mj6mJJSU7r6iWxF8Nx5t0p2KZd70UA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.34.0.tgz",
+      "integrity": "sha512-+ZLABLbe08U6Xg8Eyu0AJCjchk9Kpah8lUEAUhaNdY2M5RdEqlm4LkvlCdmq425KzsrTX0AeWaCfcvGqFr4+lw==",
       "requires": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/koa": "2.13.4",
         "@types/koa__router": "8.0.7"
       }
     },
     "@opentelemetry/instrumentation-lru-memoizer": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.31.0.tgz",
-      "integrity": "sha512-eAUwYtTK7Tmb/ruXSBB5wW4lXW8HsmWmbmFDL8rmOo2eCCKTZocm9Mk79scKminA59Mb5vfZjn7r21KRlYFCSQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.32.0.tgz",
+      "integrity": "sha512-wXTfawB+RBnPH2xF5S9vOEMXYHY15oRKhV94dWb61k/dMqlGgfcFug6/qY4vkZgm58GhNbFoF5RWNNUpU4LOAQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0"
+        "@opentelemetry/instrumentation": "^0.34.0"
       }
     },
     "@opentelemetry/instrumentation-memcached": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.30.1.tgz",
-      "integrity": "sha512-DBDhMeigjp3yr37CokJWpPqj4ME6LT8i2Ft8yz6Ole3yLjcrmAKuVvHl2UM7E8h2JmSd/lwhBCBCO2rH4B+UrQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.31.0.tgz",
+      "integrity": "sha512-wkoZQ6TyHWuaHTmV/MSIqJzFyEnjWj6hdRftX6eJUv1xalYjrxDZW6gFiByRdlVKupuksIW3/ntvozyLhzbJqQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/memcached": "^2.2.6"
       }
     },
     "@opentelemetry/instrumentation-mongodb": {
-      "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.32.2.tgz",
-      "integrity": "sha512-C3OWsc1Fan+xl+ly0C8VxiICb30xevoG82Ytx+4LOemiZc37WPcTdJMrXi2MyOtRc7kqN6xYf2zbU/n+y8BsUQ==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.33.0.tgz",
+      "integrity": "sha512-bjRF55grOFRn5XQxm1yDL56FD9UVvmIcBDSsgA0dbUr3VOUu3sN7o34t2uDx7EpnfwhMeAvOBO1wbWXdHBzapg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-mongoose": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.31.1.tgz",
-      "integrity": "sha512-g7dMXFUGjRioH3HfSDjgQi/YGdiWaLvLdux0TR1nSgrF3PGHk2djL2Nv4hxibz396QyEEtn9pyXvIwGLNHXGKw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.32.0.tgz",
+      "integrity": "sha512-Br8x76u1xsMiU4nwioYX8NwIBxl4Kt0dTDrZvqtwLkmr7gmHoxApN17QquQcEcuTfonQ4NXIB3A/k1BiPAaq/g==",
       "requires": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-mysql": {
-      "version": "0.31.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.31.2.tgz",
-      "integrity": "sha512-YcJ3YeQ3tisHWWpUfD156Koc+LfktOzJD4tAFLaqoKTcvu5gl6VfKJ3scoTOtVxxvFBAK66MvMMXMHSaCv9b5w==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.32.0.tgz",
+      "integrity": "sha512-9BGbc0wiNokflUKmI3WEOnmCqp9QffcnrIoIs2cjqQekZGAzSmL7tyyL3SoW/qXWOUP8FM+OuEomklujNOZYbg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.19"
       }
     },
     "@opentelemetry/instrumentation-mysql2": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.32.1.tgz",
-      "integrity": "sha512-tNh393lu/n1FEIvaeHo9VodiFYak8TKyVDjaYhWaBM5Oy4UbMUmCSo52H9Mbbi/c1Y24h8V2ppu04amQvtj9gg==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.33.0.tgz",
+      "integrity": "sha512-DVWkr/WkALmIdtLoiVp/vgZVOXUCFvnlKOEz+LOQMHOktm0FLhdHRjX7jJhtVtEO7DdZQRnfpUYv8zP37gMawQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.31.1.tgz",
-      "integrity": "sha512-XWA91MFtVmdmcbvq5oFFXtot2GrKbWrR2R9gPVXmsOnW/4fnQg7id9kMFta77/5q16BYLVfZ9VLblwjdTdDVYw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.32.0.tgz",
+      "integrity": "sha512-kpzegHf1tNqtZhC+BCM/B9n3/e+vBYYYGZK+HUgiL/lHUoUf3Lsj6869eckSgucrScLjDGNBuo5j8JAkdNJ5zw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-net": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.30.2.tgz",
-      "integrity": "sha512-1k5oY/MT3q7v1t0gK5D0C/xF24FMy8YewxPuTH4b4DRFILxo5MriRZ4QWPM4LmFUxkqJsHrt4mW3LPVejiYYmA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.31.0.tgz",
+      "integrity": "sha512-uzgI0AMZWYqN/w8oQ3EwSpFKnZ+yMVbzoRczh8pVZgWR8Xw35/h9GfgrOO2Sb9/4nf75bwO83hjRkW4KfsEE7w==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-pg": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.32.0.tgz",
-      "integrity": "sha512-ZY2zcJOwCwSbY8a0wAwUgQXhOMIOaTGSWhHWkDJV92PY1T5E4r0B0kjF9EsBkT8cFqHEgVxt1ZeodfD3Wilh3A==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.33.0.tgz",
+      "integrity": "sha512-RYs4xsGkIKM5cw/3WPRKxjDyLd1DXhwYaNugJlbozDzkToZ1SRzd8I2qAJ2nTTKHtFrWYCqZILPXnRguZNHmnA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.3"
       }
     },
     "@opentelemetry/instrumentation-pino": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.32.1.tgz",
-      "integrity": "sha512-GfMQ2U8/37NK/7YDF1sqI8vQkxVwXVfgBkFh0ZXI387nkTYvzp2EqBsGSJ9c1aWPeDPI4sqpFtkZosu1TrfXnA==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.33.0.tgz",
+      "integrity": "sha512-2ZU6ri1/90UpLIZGIeF48BG58mZEtHBUgxYPj08J+HbatHkLg5RQtIy0Q9P9UbAAq+2+Izh2RDm5K1T5OVGkMg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0"
+        "@opentelemetry/instrumentation": "^0.34.0"
       }
     },
     "@opentelemetry/instrumentation-redis": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.33.1.tgz",
-      "integrity": "sha512-17xuGpIXo1ugQo51xPtzDuE24qc95MQuEdWTFXESOgFWd+FshpS9+TF4RmegK6hhZ81ekkwwGNK+fYFmWKnCXw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.34.0.tgz",
+      "integrity": "sha512-fUrU3Ekhxu6bcnurP/rfhZJNxQV9qUP2vQSQSRwPiPZs+s3UKuY19rQEFCST10jF66rQrqB32VwnGqeQyZbHlw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/redis": "2.8.31"
       }
     },
     "@opentelemetry/instrumentation-redis-4": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.33.1.tgz",
-      "integrity": "sha512-LoJRsiDKSFZ0cU9sicHfZqqpaunCwI7h2CWZvIrenOdXdg8TLpeXumzEiFbaCkZ80fzxsM6IqEzCtiVo4+n93w==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.34.0.tgz",
+      "integrity": "sha512-b3joRK8+aSszaznUoL8vtZrwreN/CJY0VZbmE3HE8IUvOc6W0QRvOl7fDAJ2z56lDT0f7cZSV05gpvslXgZeWg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-restify": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.30.1.tgz",
-      "integrity": "sha512-5ss8mqGhtZIQ38C1bOSWb1Pu5QgRejLsdxTR94IYsLhSkBD4boK7EhgwxXpYz80FCqDe+3852bTS65e3PFU8mw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.31.0.tgz",
+      "integrity": "sha512-b0AWFZ9+tm4Iaydt1AquBpsQty+Uv1YQ3C9Jb4/JTknWDWW63tb8FoCcALMPYDulvOgH+PPDvtvZY0Q0Imbstg==",
       "requires": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-router": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.31.0.tgz",
-      "integrity": "sha512-5sYa7s7vKGcBUppT5ejRlo6OXuFTaVAjr7ucLcSh45LuYDqTFZRMkhE4wh4DQ7TnrAenS1Nxqv/6/hy0rgyxPA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.32.0.tgz",
+      "integrity": "sha512-s7RywETzH4FW+8yzPqbBYh5BdtILjM9cjhofucVXDcKY3tNSJA1gGBTCDOK49+ec9zyo1e+nchiYaeS9IW8U/A==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-tedious": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.4.1.tgz",
-      "integrity": "sha512-1vDzO5JfhyZQ60X52gT3ZSsTVpc24SGmEmjhfidQgGHla2lpqVwsfouwTNCkgWZ1IkO4nA127+WV9+ova9LnTw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.5.0.tgz",
+      "integrity": "sha512-PaaB56cggwg69JPTi3CYR0JnXV+hjBFAnkhKKwIKeaiHew7txOfPZo8S1cEW058jOPFySV+Qg8ZkGApXkvp5zg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/tedious": "^4.0.6"
       }
     },
     "@opentelemetry/instrumentation-winston": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.30.1.tgz",
-      "integrity": "sha512-qONu+aYObIvFVkW/mq4EK4a7kspMvouHnZfQUZpywHnY/0wk9YlaNsnRggNmKb+Ig5ThxxB+sldFyZrlKdoncQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.31.0.tgz",
+      "integrity": "sha512-+19vD2v9wWuUP4Hz0dHcpeT5/5Ke0dtIeZ+zCFXJA4lLLR9QeKMN0ORFlbpAOBwKjjuaBHXnMAwuoMSdOUxCKw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0"
+        "@opentelemetry/instrumentation": "^0.34.0"
       }
     },
     "@opentelemetry/propagation-utils": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.29.0.tgz",
-      "integrity": "sha512-9KyRHd3/v+DhcoGDbkbSrxQlDRhTcGwiXUvgjjWkCmmzQ4Z8G5WHgXxoGBe6crcamGk9X+SyKtePkq9dYG2eaA==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.29.1.tgz",
+      "integrity": "sha512-sSlkke2RrUuWcbhsRUxbwn6G9XtPa1b8zUoudvxxwvs7nCPE2pQRy32JyqT7CbuWf6gQPK/R1u54T79c93oyGQ==",
       "requires": {}
     },
     "@opentelemetry/propagator-aws-xray": {
@@ -2450,6 +2437,16 @@
       "requires": {
         "@opentelemetry/core": "1.8.0",
         "@opentelemetry/semantic-conventions": "1.8.0"
+      }
+    },
+    "@opentelemetry/sdk-metrics": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.8.0.tgz",
+      "integrity": "sha512-+KYb+uj0vHhl8xzJO+oChS4oP1e+/2Wl3SXoHoIdcEjd1TQfDV+lxOm4oqxWq6wykXvI35/JHyejxSoT+qxGmg==",
+      "requires": {
+        "@opentelemetry/core": "1.8.0",
+        "@opentelemetry/resources": "1.8.0",
+        "lodash.merge": "4.6.2"
       }
     },
     "@opentelemetry/semantic-conventions": {
@@ -2498,9 +2495,9 @@
       "integrity": "sha512-C1rFKGVZ8KwqhwBOYlpoybTSRtxu2433ea6JaO3amc6ubEe08yQoFsPa9aU9YqvX7ppeZ25CnCtC4AH9mhtxsQ=="
     },
     "@types/bluebird": {
-      "version": "3.5.37",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.37.tgz",
-      "integrity": "sha512-g2qEd+zkfkTEudA2SrMAeAvY7CrFqtbsLILm2dT2VIeKTqMqVzcdfURlvu6FU3srRgbmXN1Srm94pg34EIehww=="
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.38.tgz",
+      "integrity": "sha512-yR/Kxc0dd4FfwtEoLZMoqJbM/VE/W7hXn/MIjb+axcwag0iFmSPK7OBUZq1YWLynJUoWQkfUrI7T0HDqGApNSg=="
     },
     "@types/body-parser": {
       "version": "1.19.2",
@@ -2689,9 +2686,9 @@
       }
     },
     "@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+      "version": "18.11.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.15.tgz",
+      "integrity": "sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw=="
     },
     "@types/pg": {
       "version": "8.6.1",
@@ -2931,12 +2928,6 @@
         "has-symbols": "^1.0.3"
       }
     },
-    "graphql": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-      "peer": true
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2999,6 +2990,11 @@
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lru-cache": {
       "version": "6.0.0",

--- a/examples/hello-node-express/package.json
+++ b/examples/hello-node-express/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@honeycombio/opentelemetry-node": "file:../../dist/src",
-    "@opentelemetry/auto-instrumentations-node": "^0.34.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.35.0",
+    "@opentelemetry/sdk-metrics": "^1.8.0",
     "express": "^4.18.2"
   }
 }

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -5,7 +5,6 @@ x-env-base: &env_base
   HONEYCOMB_API_KEY: bogus_key
   HONEYCOMB_DATASET: bogus_dataset
   HONEYCOMB_METRICS_DATASET: bogus_dataset
-  OTEL_METRIC_EXPORT_INTERVAL: 100
   OTEL_SERVICE_NAME: "hello-node-express"
   DEBUG: "true"
 

--- a/smoke-tests/smoke-sdk-http-ts.bats
+++ b/smoke-tests/smoke-sdk-http-ts.bats
@@ -4,6 +4,7 @@ load test_helpers/utilities
 
 CONTAINER_NAME="app-sdk-http-ts"
 TRACER_NAME="hello-world-tracer"
+METER_NAME="hello-world-meter"
 
 setup_file() {
 	echo "# 🚧" >&3
@@ -11,6 +12,7 @@ setup_file() {
 	wait_for_ready_app ${CONTAINER_NAME}
 	curl --silent "http://localhost:3000"
 	wait_for_traces
+  wait_for_metrics 15
 }
 
 teardown_file() {
@@ -47,4 +49,9 @@ teardown_file() {
 @test "BaggageSpanProcessor: key-values added to baggage appear on child spans" {
 	result=$(span_attributes_for ${TRACER_NAME} | jq "select(.key == \"for_the_children\").value.stringValue")
 	assert_equal "$result" '"another important value"'
+}
+
+@test "Manual instrumentation produces metrics" {
+    result=$(metric_names_for ${METER_NAME})
+    assert_equal "$result" '"sheep"'
 }

--- a/smoke-tests/smoke-sdk-http.bats
+++ b/smoke-tests/smoke-sdk-http.bats
@@ -4,6 +4,7 @@ load test_helpers/utilities
 
 CONTAINER_NAME="app-sdk-http"
 TRACER_NAME="hello-world-tracer"
+METER_NAME="hello-world-meter"
 
 setup_file() {
 	echo "# 🚧" >&3
@@ -11,6 +12,7 @@ setup_file() {
 	wait_for_ready_app ${CONTAINER_NAME}
 	curl --silent "http://localhost:3000"
 	wait_for_traces
+  wait_for_metrics 15
 }
 
 teardown_file() {
@@ -47,4 +49,9 @@ teardown_file() {
 @test "BaggageSpanProcessor: key-values added to baggage appear on child spans" {
 	result=$(span_attributes_for ${TRACER_NAME} | jq "select(.key == \"for_the_children\").value.stringValue")
 	assert_equal "$result" '"another important value"'
+}
+
+@test "Manual instrumentation produces metrics" {
+    result=$(metric_names_for ${METER_NAME})
+    assert_equal "$result" '"sheep"'
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #130 

## Short description of the changes

- add metrics to JS express app (already added to TS app)
- update counter to use "sheep" because we use it in other distros and smoke test for it ¯\_(ツ)_/¯
- remove metric interval from smoke tests (this caused issues with dotnet smoke testing, may be unnecessary)
- remove unused metric exporter package from our experiment when adding metrics exporter

## How to verify that this has the expected result

smoke tests pass!

If you run it locally you should see the output in `smoke-tests/collector/data-results/data-app-sdk-http-ts.json` and `smoke-tests/collector/data-results/data-app-sdk-http` that includes `resourceMetrics`.

In CircleCI, the data is also saved in [artifacts](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-node/410/workflows/35504d47-5f63-4ffb-923d-3e8baaa41483/jobs/1629/artifacts).