### PR TITLE
fix: dependabot config for scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,4 @@ updates:
       - "honeycombio/telemetry-team"
     commit-message:
       prefix: "maint"
-      include_scope: true
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       - "type: dependencies"
     reviewers:
       - "honeycombio/telemetry-team"
+    commit-message:
+      prefix: "maint"
+      include_scope: true


### PR DESCRIPTION
## Which problem is this PR solving?
In #131, there was a config error which this PR fixes.

## Short description of the changes
- `include_scope: true` --> `include: "scope"`

## How to verify that this has the expected result
The [docs reference the more up to date config ](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message)option for including scope.
