### PR TITLE
feat: make metrics export configurable

### DIFF
--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -5,6 +5,8 @@ x-env-base: &env_base
   HONEYCOMB_API_KEY: bogus_key
   HONEYCOMB_DATASET: bogus_dataset
   HONEYCOMB_METRICS_DATASET: bogus_dataset
+  OTEL_METRIC_EXPORT_INTERVAL: 5000
+  OTEL_METRIC_EXPORT_TIMEOUT: 4000
   OTEL_SERVICE_NAME: "hello-node-express"
   DEBUG: "true"
 

--- a/src/exporter-utils.ts
+++ b/src/exporter-utils.ts
@@ -1,7 +1,11 @@
 import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { configureHoneycombGrpcTraceExporter } from './grpc-trace-exporter';
-import { HoneycombOptions } from './honeycomb-options';
+import {
+  getMetricsInterval,
+  getMetricsTimeout,
+  HoneycombOptions,
+} from './honeycomb-options';
 import { configureHoneycombHttpProtoMetricExporter } from './http-proto-metric-exporter';
 import { configureHoneycombHttpProtoTraceExporter } from './http-proto-trace-exporter';
 
@@ -41,9 +45,9 @@ export function getHoneycombMetricReader(
     return undefined;
   }
   return new PeriodicExportingMetricReader({
-    // when we add grpc exporter support, we can do the check here to deicde which exporter to pass in
+    // when we add grpc exporter support, we can do the check here to decide which exporter to pass in
     exporter: configureHoneycombHttpProtoMetricExporter(options),
-    exportIntervalMillis: options?.metricsInterval,
-    exportTimeoutMillis: options?.metricsTimeout,
+    exportIntervalMillis: getMetricsInterval(),
+    exportTimeoutMillis: getMetricsTimeout(),
   });
 }

--- a/src/exporter-utils.ts
+++ b/src/exporter-utils.ts
@@ -43,7 +43,7 @@ export function getHoneycombMetricReader(
   return new PeriodicExportingMetricReader({
     // when we add grpc exporter support, we can do the check here to deicde which exporter to pass in
     exporter: configureHoneycombHttpProtoMetricExporter(options),
-    exportIntervalMillis: options?.metricsInterval || 60000,
-    exportTimeoutMillis: options?.metricsTimeout || 30000,
+    exportIntervalMillis: options?.metricsInterval,
+    exportTimeoutMillis: options?.metricsTimeout,
   });
 }

--- a/src/exporter-utils.ts
+++ b/src/exporter-utils.ts
@@ -43,5 +43,7 @@ export function getHoneycombMetricReader(
   return new PeriodicExportingMetricReader({
     // when we add grpc exporter support, we can do the check here to deicde which exporter to pass in
     exporter: configureHoneycombHttpProtoMetricExporter(options),
+    exportIntervalMillis: options?.metricsInterval || 60000,
+    exportTimeoutMillis: options?.metricsTimeout || 30000,
   });
 }

--- a/src/honeycomb-options.ts
+++ b/src/honeycomb-options.ts
@@ -106,8 +106,8 @@ export function computeOptions(options?: HoneycombOptions): HoneycombOptions {
     dataset: env.HONEYCOMB_DATASET || options?.dataset,
     metricsDataset: env.HONEYCOMB_METRICS_DATASET || options?.metricsDataset,
     sampleRate: getSampleRate(env, options),
-    metricInterval: getMetricInterval(env),
-    metricTimeout: getMetricTimeout(env),
+    metricsInterval: getMetricsInterval(env),
+    metricsTimeout: getMetricsTimeout(env),
     debug: env.DEBUG || options?.debug || false,
     localVisualizations:
       env.HONEYCOMB_ENABLE_LOCAL_VISUALIZATIONS ||
@@ -351,14 +351,14 @@ function isHttpProtocol(protcol?: OtlpProtocol): boolean {
   return false;
 }
 
-function getMetricInterval(env: HoneycombEnvironmentOptions): number {
+function getMetricsInterval(env: HoneycombEnvironmentOptions): number {
   // TODO: must be less than OTEL_METRIC_EXPORT_TIMEOUT
   if (env.OTEL_METRIC_EXPORT_INTERVAL && env.OTEL_METRIC_EXPORT_INTERVAL > 0) {
     return env.OTEL_METRIC_EXPORT_INTERVAL;
   } else return DEFAULT_METRIC_INTERVAL;
 }
 
-function getMetricTimeout(env: HoneycombEnvironmentOptions): number {
+function getMetricsTimeout(env: HoneycombEnvironmentOptions): number {
   // TODO: must be greater than OTEL_METRIC_EXPORT_INTERVAL
   if (env.OTEL_METRIC_EXPORT_TIMEOUT && env.OTEL_METRIC_EXPORT_TIMEOUT > 0) {
     return env.OTEL_METRIC_EXPORT_TIMEOUT;

--- a/test/honeycomb-options.test.ts
+++ b/test/honeycomb-options.test.ts
@@ -576,4 +576,12 @@ describe('metrics interval and timeout options', () => {
     expect(options.metricsInterval).toBe(60000);
     expect(options.metricsTimeout).toBe(30000);
   });
+
+  it('uses default values if interval is lower than timeout', () => {
+    process.env.OTEL_METRIC_EXPORT_INTERVAL = '1000';
+    process.env.OTEL_METRIC_EXPORT_TIMEOUT = '2000';
+    const options = computeOptions();
+    expect(options.metricsInterval).toBe(60000);
+    expect(options.metricsTimeout).toBe(30000);
+  });
 });

--- a/test/honeycomb-options.test.ts
+++ b/test/honeycomb-options.test.ts
@@ -1,5 +1,7 @@
 import {
   computeOptions,
+  getMetricsInterval,
+  getMetricsTimeout,
   HoneycombOptions,
   IGNORED_DATASET_ERROR,
   isClassic,
@@ -547,41 +549,37 @@ describe('maybeAppendMetricsPath', () => {
 });
 
 describe('metrics interval and timeout options', () => {
-  it('uses default values if not set', () => {
-    const options = computeOptions();
-    expect(options.metricsInterval).toBe(60000);
-    expect(options.metricsTimeout).toBe(30000);
+  it('is undefined if not set', () => {
+    const metricInterval = getMetricsInterval();
+    const metricTimeout = getMetricsTimeout();
+    expect(metricInterval).toBeUndefined();
+    expect(metricTimeout).toBeUndefined();
   });
 
   it('uses metrics interval and timeout from env vars', () => {
     process.env.OTEL_METRIC_EXPORT_INTERVAL = '2000';
     process.env.OTEL_METRIC_EXPORT_TIMEOUT = '1000';
-    const options = computeOptions();
-    expect(options.metricsInterval).toBe(2000);
-    expect(options.metricsTimeout).toBe(1000);
+    const metricInterval = getMetricsInterval();
+    const metricTimeout = getMetricsTimeout();
+    expect(metricInterval).toBe(2000);
+    expect(metricTimeout).toBe(1000);
   });
 
-  it('uses default values if set to negative numbers', () => {
+  it('is undefined if set to negative numbers', () => {
     process.env.OTEL_METRIC_EXPORT_INTERVAL = '-2000';
     process.env.OTEL_METRIC_EXPORT_TIMEOUT = '-1000';
-    const options = computeOptions();
-    expect(options.metricsInterval).toBe(60000);
-    expect(options.metricsTimeout).toBe(30000);
+    const metricInterval = getMetricsInterval();
+    const metricTimeout = getMetricsTimeout();
+    expect(metricInterval).toBeUndefined();
+    expect(metricTimeout).toBeUndefined();
   });
 
-  it('uses default values if set to zero', () => {
+  it('is undefined if set to zero', () => {
     process.env.OTEL_METRIC_EXPORT_INTERVAL = '0';
     process.env.OTEL_METRIC_EXPORT_TIMEOUT = '0';
-    const options = computeOptions();
-    expect(options.metricsInterval).toBe(60000);
-    expect(options.metricsTimeout).toBe(30000);
-  });
-
-  it('uses default values if interval is lower than timeout', () => {
-    process.env.OTEL_METRIC_EXPORT_INTERVAL = '1000';
-    process.env.OTEL_METRIC_EXPORT_TIMEOUT = '2000';
-    const options = computeOptions();
-    expect(options.metricsInterval).toBe(60000);
-    expect(options.metricsTimeout).toBe(30000);
+    const metricInterval = getMetricsInterval();
+    const metricTimeout = getMetricsTimeout();
+    expect(metricInterval).toBeUndefined();
+    expect(metricTimeout).toBeUndefined();
   });
 });

--- a/test/honeycomb-options.test.ts
+++ b/test/honeycomb-options.test.ts
@@ -545,3 +545,35 @@ describe('maybeAppendMetricsPath', () => {
     expect(endpoint).toBe('https://api.honeycomb.io/v1/metrics');
   });
 });
+
+describe('metrics interval and timeout options', () => {
+  it('uses default values if not set', () => {
+    const options = computeOptions();
+    expect(options.metricsInterval).toBe(60000);
+    expect(options.metricsTimeout).toBe(30000);
+  });
+
+  it('uses metrics interval and timeout from env vars', () => {
+    process.env.OTEL_METRIC_EXPORT_INTERVAL = '2000';
+    process.env.OTEL_METRIC_EXPORT_TIMEOUT = '1000';
+    const options = computeOptions();
+    expect(options.metricsInterval).toBe(2000);
+    expect(options.metricsTimeout).toBe(1000);
+  });
+
+  it('uses default values if set to negative numbers', () => {
+    process.env.OTEL_METRIC_EXPORT_INTERVAL = '-2000';
+    process.env.OTEL_METRIC_EXPORT_TIMEOUT = '-1000';
+    const options = computeOptions();
+    expect(options.metricsInterval).toBe(60000);
+    expect(options.metricsTimeout).toBe(30000);
+  });
+
+  it('uses default values if set to zero', () => {
+    process.env.OTEL_METRIC_EXPORT_INTERVAL = '0';
+    process.env.OTEL_METRIC_EXPORT_TIMEOUT = '0';
+    const options = computeOptions();
+    expect(options.metricsInterval).toBe(60000);
+    expect(options.metricsTimeout).toBe(30000);
+  });
+});

--- a/test/setup-jest.ts
+++ b/test/setup-jest.ts
@@ -15,4 +15,7 @@ afterEach(() => {
 
   delete process.env.OTEL_SERVICE_NAME;
   delete process.env.OTEL_EXPORTER_OTLP_PROTOCOL;
+
+  delete process.env.OTEL_METRIC_EXPORT_INTERVAL;
+  delete process.env.OTEL_METRIC_EXPORT_TIMEOUT;
 });


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #138 

## Short description of the changes

- adds support for environment variables `OTEL_METRIC_EXPORT_INTERVAL` and `OTEL_METRIC_EXPORT_TIMEOUT`
- uses provided environment variables to set `exportIntervalMillis` and `exportTimeoutMillis` in metric exporter

Ideally these environment variables can/will be supported upstream, but in the meantime this should allow end users to configure timeout and interval behavior if needed. This is also used in our smoke tests to reduce test time.

Note: Validation logic to ensure the metric interval is higher than the metric timeout is handled upstream, and not included in this distro. If the values provided are not positive numbers, we'll simply leave as undefined (regular default behavior). The default values of 60000 and 30000 are set and used upstream.

## How to verify that this has the expected result

Set these environment variables to low numbers and run the example express apps with debug to see more frequent export of metrics.