### PR TITLE
fix: Allow user specified resource attributes

### DIFF
--- a/examples/hello-node-express-ts/README.md
+++ b/examples/hello-node-express-ts/README.md
@@ -15,15 +15,22 @@ npm run setup
 ### Running the main application
 
 ```bash
-HONEYCOMB_API_KEY={apikey} OTEL_SERVICE_NAME="hello-node-express" npm start
+HONEYCOMB_API_KEY={apikey} OTEL_SERVICE_NAME="hello-node-express-ts" npm start
 ```
 
 Alternatively, to export telemetry using `gRPC` instead of `http/protobuf`:
 
 ```bash
-HONEYCOMB_API_KEY={apikey} OTEL_SERVICE_NAME="hello-node-express" OTEL_EXPORTER_OTLP_PROTOCOL=grpc npm start
+HONEYCOMB_API_KEY={apikey} OTEL_SERVICE_NAME="hello-node-express-ts" OTEL_EXPORTER_OTLP_PROTOCOL=grpc npm start
 ```
 
 To just get the JavaScript files, run `npm install` then `npm run build` and see the JS files in the `dist` directory.
 
 To run the built JavaScript files, run `npm run start-js`.
+
+You can now curl the app:
+
+```bash
+curl localhost:3000
+Hello, World!
+```

--- a/examples/hello-node-express-ts/instrumentation.ts
+++ b/examples/hello-node-express-ts/instrumentation.ts
@@ -4,6 +4,7 @@ import {
   HoneycombSDK,
 } from '@honeycombio/opentelemetry-node';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { Resource } from '@opentelemetry/resources';
 
 const config: HoneycombOptions = {
   apiKey: process.env.HONEYCOMB_API_KEY || '',
@@ -12,6 +13,10 @@ const config: HoneycombOptions = {
   instrumentations: [getNodeAutoInstrumentations()],
   metricsDataset:
     process.env.HONEYCOMB_METRICS_DATASET || 'hello-node-express-ts-metrics',
+  // add app level attributes to appear on every span
+  resource: new Resource({
+    'global.build_id': process.env.APP_BUILD_ID,
+  }),
 };
 
 const sdk: NodeSDK = new HoneycombSDK(config);

--- a/examples/hello-node-express/README.md
+++ b/examples/hello-node-express/README.md
@@ -23,3 +23,10 @@ Alternatively, to export telemetry using `gRPC` instead of `http/protobuf`:
 ```bash
 HONEYCOMB_API_KEY={apikey} OTEL_SERVICE_NAME="hello-node-express" OTEL_EXPORTER_OTLP_PROTOCOL=grpc npm start
 ```
+
+You can now curl the app:
+
+```bash
+curl localhost:3000
+Hello, World!
+```

--- a/examples/hello-node-express/index.js
+++ b/examples/hello-node-express/index.js
@@ -3,6 +3,7 @@ const { context, metrics, propagation, trace } = require('@opentelemetry/api');
 const {
   getNodeAutoInstrumentations,
 } = require('@opentelemetry/auto-instrumentations-node');
+const { Resource } = require('@opentelemetry/resources');
 
 const sdk = new HoneycombSDK({
   apiKey: process.env.HONEYCOMB_API_KEY || '',
@@ -11,6 +12,10 @@ const sdk = new HoneycombSDK({
   instrumentations: [getNodeAutoInstrumentations()],
   metricsDataset:
     process.env.HONEYCOMB_METRICS_DATASET || 'hello-node-express-ts-metrics',
+  // add app level attributes to appear on every span
+  resource: new Resource({
+    'global.build_id': process.env.APP_BUILD_ID,
+  }),
 });
 
 // alternatively, use environment variables for

--- a/examples/hello-node-express/index.js
+++ b/examples/hello-node-express/index.js
@@ -11,7 +11,7 @@ const sdk = new HoneycombSDK({
   debug: true,
   instrumentations: [getNodeAutoInstrumentations()],
   metricsDataset:
-    process.env.HONEYCOMB_METRICS_DATASET || 'hello-node-express-ts-metrics',
+    process.env.HONEYCOMB_METRICS_DATASET || 'hello-node-express-metrics',
   // add app level attributes to appear on every span
   resource: new Resource({
     'global.build_id': process.env.APP_BUILD_ID,

--- a/src/opentelemetry-node.ts
+++ b/src/opentelemetry-node.ts
@@ -18,7 +18,7 @@ export class HoneycombSDK extends NodeSDK {
     super({
       ...opts,
       serviceName: opts?.serviceName,
-      resource: configureHoneycombResource(),
+      resource: configureHoneycombResource(opts),
       metricReader: getHoneycombMetricReader(opts),
       spanProcessor: configureBatchWithBaggageSpanProcessor(opts),
       sampler: configureDeterministicSampler(opts?.sampleRate),

--- a/src/resource-builder.ts
+++ b/src/resource-builder.ts
@@ -1,4 +1,5 @@
 import { Resource } from '@opentelemetry/resources';
+import { HoneycombOptions } from './honeycomb-options';
 import { VERSION } from './version';
 
 /**
@@ -6,9 +7,9 @@ import { VERSION } from './version';
  * added resource attributes specific to the Honeycomb Distro
  * @returns a Resource instance
  */
-export function configureHoneycombResource(): Resource {
+export function configureHoneycombResource(opts?: HoneycombOptions): Resource {
   return new Resource({
     'honeycomb.distro.version': VERSION,
     'honeycomb.distro.runtime_version': process.versions.node,
-  });
+  }).merge(opts?.resource ? opts.resource : null);
 }

--- a/test/resource-builder.test.ts
+++ b/test/resource-builder.test.ts
@@ -10,3 +10,17 @@ test('it should return a Resource', () => {
     process.versions.node,
   );
 });
+
+test('it should merge resource attributes provided from another resource', () => {
+  const resource = configureHoneycombResource({
+    resource: new Resource({
+      myTestAttr: 'my-test-attr',
+    }),
+  });
+  expect(resource).toBeInstanceOf(Resource);
+  expect(resource.attributes['honeycomb.distro.version']).toEqual(VERSION);
+  expect(resource.attributes['honeycomb.distro.runtime_version']).toEqual(
+    process.versions.node,
+  );
+  expect(resource.attributes.myTestAttr).toEqual('my-test-attr');
+});


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #151 

## Short description of the changes
- Changed the Resource builder to merge with any resources passed in when initializing the distro
- Added tests
- Added examples

## How to verify that this has the expected result
1. Run the express or typescript express example
2. Set API keys so that data is being sent to Honeycomb (console spans don't seem to expand resource attributes and they show up as `resource: Resource { attributes: [Object] }`
3. Check in honeycomb to see if there's a `global.build_id` attribute on spans
