### PR TITLE
maint: add observable gauge example

### DIFF
--- a/smoke-tests/smoke-sdk-grpc-ts.bats
+++ b/smoke-tests/smoke-sdk-grpc-ts.bats
@@ -5,6 +5,7 @@ load test_helpers/utilities
 CONTAINER_NAME="app-sdk-grpc-ts"
 TRACER_NAME="hello-world-tracer"
 METER_NAME="hello-world-meter"
+NODE_METER_NAME="node-monitor-meter"
 
 setup_file() {
 	echo "# 🚧" >&3
@@ -51,7 +52,11 @@ teardown_file() {
 	assert_equal "$result" '"another important value"'
 }
 
-@test "Manual instrumentation produces metrics" {
+@test "Manual instrumentation produces metrics for counter" {
     result=$(metric_names_for ${METER_NAME})
     assert_equal "$result" '"sheep"'
+}
+@test "Manual instrumentation produces metrics for observable gauge" {
+    result=$(metric_names_for ${NODE_METER_NAME})
+    assert_equal "$result" '"process.runtime.nodejs.memory.heap.total"'
 }

--- a/smoke-tests/smoke-sdk-http-ts.bats
+++ b/smoke-tests/smoke-sdk-http-ts.bats
@@ -5,6 +5,7 @@ load test_helpers/utilities
 CONTAINER_NAME="app-sdk-http-ts"
 TRACER_NAME="hello-world-tracer"
 METER_NAME="hello-world-meter"
+NODE_METER_NAME="node-monitor-meter"
 
 setup_file() {
 	echo "# 🚧" >&3
@@ -51,7 +52,11 @@ teardown_file() {
 	assert_equal "$result" '"another important value"'
 }
 
-@test "Manual instrumentation produces metrics" {
+@test "Manual instrumentation produces metrics for counter" {
     result=$(metric_names_for ${METER_NAME})
     assert_equal "$result" '"sheep"'
+}
+@test "Manual instrumentation produces metrics for observable gauge" {
+    result=$(metric_names_for ${NODE_METER_NAME})
+    assert_equal "$result" '"process.runtime.nodejs.memory.heap.total"'
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- confusion about how to add an observable gauge metric

## Short description of the changes

- add new meter to typescript example app
- log nodejs runtime memory heap with observable gauge on new meter
- add meter checks to smoke tests

## How to verify that this has the expected result

smoke tests should pass, and uploaded artifacts in circle should contain the new metrics

also see the metrics in honeycomb if running the app

![hello-node-express-ts-metrics](https://user-images.githubusercontent.com/29520003/221056603-ca5e9e46-6e32-482c-8eec-ec778c5fba08.png)
