### PR TITLE
docs: update example to trace exception in span

### DIFF
--- a/examples/hello-node-express-ts/index.ts
+++ b/examples/hello-node-express-ts/index.ts
@@ -19,13 +19,13 @@ const port = 3000;
 // express supports async handlers but the @types definition is wrong: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/50871
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
 app.get('/', async (_req: Request, res: Response, next: NextFunction) => {
+  const tracer: Tracer = trace.getTracer('hello-world-tracer');
+  const meter: Meter = metrics.getMeter('hello-world-meter');
+  const nodeMonitorMeter: Meter = metrics.getMeter('node-monitor-meter');
   try {
     res.statusCode = 200;
     res.setHeader('Content-Type', 'text/plain');
     const sayHello = () => 'Hello world!';
-    const tracer: Tracer = trace.getTracer('hello-world-tracer');
-    const meter: Meter = metrics.getMeter('hello-world-meter');
-    const nodeMonitorMeter: Meter = metrics.getMeter('node-monitor-meter');
     const counter: Counter = meter.createCounter('sheep');
 
     counter.add(1);

--- a/examples/hello-node-express-ts/index.ts
+++ b/examples/hello-node-express-ts/index.ts
@@ -4,6 +4,7 @@ import {
   Counter,
   Meter,
   metrics,
+  ObservableGauge,
   propagation,
   Span,
   SpanStatusCode,
@@ -31,7 +32,7 @@ app.get('/', async (_req: Request, res: Response, next: NextFunction) => {
 
     counter.add(1);
 
-    const gauge = nodeMonitorMeter.createObservableGauge(
+    const gauge: ObservableGauge = nodeMonitorMeter.createObservableGauge(
       'process.runtime.nodejs.memory.heap.total',
       {
         unit: 'By',

--- a/examples/hello-node-express-ts/index.ts
+++ b/examples/hello-node-express-ts/index.ts
@@ -6,6 +6,7 @@ import {
   metrics,
   propagation,
   Span,
+  SpanStatusCode,
   trace,
   Tracer,
   ValueType,
@@ -63,6 +64,16 @@ app.get('/', async (_req: Request, res: Response, next: NextFunction) => {
     sayHello();
     res.end('Hello, World!\n');
   } catch (err) {
+    tracer.startActiveSpan('error', (span) => {
+      span.recordException(err as Error);
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: 'i tried and i failed',
+      });
+      span.end();
+    });
+    res.status(418);
+    res.send('There was an error. Please try again later!\n');
     next(err);
   }
 });

--- a/smoke-tests/smoke-sdk-grpc-ts.bats
+++ b/smoke-tests/smoke-sdk-grpc-ts.bats
@@ -39,7 +39,8 @@ teardown_file() {
 
 @test "Manual instrumentation produces span with name of span" {
 	result=$(span_names_for ${TRACER_NAME})
-	assert_equal "$result" '"sleep"'
+	assert_equal "$result" '"sleep"
+"try-catch"'
 }
 
 @test "Manual instrumentation adds custom attribute" {

--- a/smoke-tests/smoke-sdk-grpc-ts.bats
+++ b/smoke-tests/smoke-sdk-grpc-ts.bats
@@ -40,7 +40,7 @@ teardown_file() {
 @test "Manual instrumentation produces span with name of span" {
 	result=$(span_names_for ${TRACER_NAME})
 	assert_equal "$result" '"sleep"
-"try-catch"'
+"request-handler"'
 }
 
 @test "Manual instrumentation adds custom attribute" {

--- a/smoke-tests/smoke-sdk-http-ts.bats
+++ b/smoke-tests/smoke-sdk-http-ts.bats
@@ -39,7 +39,8 @@ teardown_file() {
 
 @test "Manual instrumentation produces span with name of span" {
 	result=$(span_names_for ${TRACER_NAME})
-	assert_equal "$result" '"sleep"'
+	assert_equal "$result" '"sleep"
+"try-catch"'
 }
 
 @test "Manual instrumentation adds custom attribute" {

--- a/smoke-tests/smoke-sdk-http-ts.bats
+++ b/smoke-tests/smoke-sdk-http-ts.bats
@@ -13,7 +13,7 @@ setup_file() {
 	wait_for_ready_app ${CONTAINER_NAME}
 	curl --silent "http://localhost:3000"
 	wait_for_traces
-    wait_for_metrics 15
+  wait_for_metrics 15
 }
 
 teardown_file() {

--- a/smoke-tests/smoke-sdk-http-ts.bats
+++ b/smoke-tests/smoke-sdk-http-ts.bats
@@ -40,7 +40,7 @@ teardown_file() {
 @test "Manual instrumentation produces span with name of span" {
 	result=$(span_names_for ${TRACER_NAME})
 	assert_equal "$result" '"sleep"
-"try-catch"'
+"request-handler"'
 }
 
 @test "Manual instrumentation adds custom attribute" {


### PR DESCRIPTION
## Which problem is this PR solving?

- confusion about how to record an exception on a span

## Short description of the changes

- start an active span to record any exceptions from the try/catch block
- to allow for the above, tracer and meters were pulled out from the try/catch block
- add missing type for observable gauge

## How to verify that this has the expected result

add `throw new Error()` in the try block and see the status code and message, and well as the stacktrace as a span event in `exception.stacktrace`.

![trace-with-error](https://user-images.githubusercontent.com/29520003/222754849-4477dd55-d728-4a2b-addb-07c22b8a9e3a.png)

![trace-without-error](https://user-images.githubusercontent.com/29520003/222754864-a74398c4-c7b5-4df3-9f52-640d490c0db8.png)

