### PR TITLE
maint: bump prettier from 2.8.1 to 2.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "eslint-plugin-node": "^11.1.0",
         "jest": "^29.2.0",
         "jest-junit": "^15.0.0",
-        "prettier": "2.8.1",
+        "prettier": "^2.8.4",
         "ts-jest": "^29.0.3",
         "typescript": "^4.8.4"
       },
@@ -2908,9 +2908,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
+      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -5442,9 +5442,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -8582,9 +8582,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
+      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
       "dev": true,
       "requires": {}
     },
@@ -10431,9 +10431,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -54,15 +54,15 @@
     "eslint-plugin-node": "^11.1.0",
     "jest": "^29.2.0",
     "jest-junit": "^15.0.0",
-    "prettier": "2.8.1",
+    "prettier": "^2.8.4",
     "ts-jest": "^29.0.3",
     "typescript": "^4.8.4"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.3",
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "^0.34.0",
     "@opentelemetry/exporter-metrics-otlp-grpc": "^0.34.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.34.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.34.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.34.0",
     "@opentelemetry/resources": "^1.8.0",

--- a/src/honeycomb-options.ts
+++ b/src/honeycomb-options.ts
@@ -31,13 +31,13 @@ export interface HoneycombOptions extends Partial<NodeSDKConfiguration> {
   /** The API key used to send traces telemetry to Honeycomb. Defaults to apikey if not set. */
   tracesApiKey?: string;
 
-  /** The API key used to send merics telemetry to Honeycomb. Defaults to apikey if not set. */
+  /** The API key used to send metrics telemetry to Honeycomb. Defaults to apikey if not set. */
   metricsApiKey?: string;
 
   /** The API endpoint where telemetry is sent. Defaults to 'https://api.honeycomb.io' */
   endpoint?: string;
 
-  /** The API endpint where traces telemetry is sent. Defaults to endpoint if not set. */
+  /** The API endpoint where traces telemetry is sent. Defaults to endpoint if not set. */
   tracesEndpoint?: string;
 
   /** The API endpoint where metrics telemetry is sent. Defaults to endpoint if not set. */
@@ -129,7 +129,7 @@ export function computeOptions(options?: HoneycombOptions): HoneycombOptions {
 }
 
 /**
- * Determins whether the passed in apikey is clasic (32 chars) or not.
+ * Determines whether the passed in apikey is classic (32 chars) or not.
  *
  * @param apikey the apikey
  * @returns a boolean to indicate if the apikey was a classic key
@@ -335,8 +335,8 @@ function getSampleRate(
   return DEFAULT_SAMPLE_RATE;
 }
 
-function isHttpProtocol(protcol?: OtlpProtocol): boolean {
-  switch (protcol) {
+function isHttpProtocol(protocol?: OtlpProtocol): boolean {
+  switch (protocol) {
     case 'http/json':
     case 'http/protobuf':
       return true;
@@ -360,7 +360,7 @@ export function maybeAppendTracesPath(url: string, protocol: OtlpProtocol) {
 }
 
 /**
- * Checks for and appends v1/metrics to provided URL if missingwhen using an HTTP
+ * Checks for and appends v1/metrics to provided URL if missing when using an HTTP
  * based exporter protocol.
  *
  * @param url the base URL to append traces path to if missing

--- a/src/honeycomb-options.ts
+++ b/src/honeycomb-options.ts
@@ -6,7 +6,7 @@ export enum OtlpProtocolKind {
   HttpProtobuf = 'http/protobuf',
   HttpJson = 'http/json',
 }
-export type OtlpProtocol = OtlpProtocolKind | typeof OtlpProtocols[number];
+export type OtlpProtocol = OtlpProtocolKind | (typeof OtlpProtocols)[number];
 
 export const DEFAULT_API_ENDPOINT = 'https://api.honeycomb.io';
 export const DEFAULT_SAMPLE_RATE = 1;


### PR DESCRIPTION
## Which problem is this PR solving?

- Replaces #166 

## Short description of the changes

- Bumps [prettier](https://github.com/prettier/prettier) from 2.8.1 to 2.8.4 
- Fix format based on prettier fail: add parentheses
- Fix up some typos

## How to verify that this has the expected result

check-format passes in CI ([failed CI ](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-node/576/workflows/7b390df2-388c-45e1-8bb3-933dabca3334/jobs/2252)in dependabot PR)