### PR TITLE
maint: ignore smoke test output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ dist
 # test stuff
 junit.xml
 smoke-tests/collector/data.json
+smoke-tests/collector/data-results/*.json
+smoke-tests/report.xml


### PR DESCRIPTION
## Which problem is this PR solving?

- running smoke tests locally leaves you in a dirty git state

## How to verify that this has the expected result
- `make smoke`
- `git status` should be clean
