### PR TITLE
feat: Add option to skip options validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ dist
 # test stuff
 junit.xml
 smoke-tests/collector/data.json
+smoke-tests/collector/data-results/*.json
+smoke-tests/report.xml

--- a/src/honeycomb-options.ts
+++ b/src/honeycomb-options.ts
@@ -63,6 +63,12 @@ export interface HoneycombOptions extends Partial<NodeSDKConfiguration> {
 
   /** The local visualizations flag enables logging Honeycomb URLs for completed traces. Do not use in production. */
   localVisualizations?: boolean;
+
+  /** Skip options validation warnings (eg no API key configured). This is useful when the SDK is being
+   * used in conjuction with an OpenTelemetry Collector (which will handle the API key and dataset configuration).
+   * Defaults to 'false'.
+   */
+  skipOptionsValidation?: boolean;
 }
 
 /**
@@ -103,7 +109,16 @@ export function computeOptions(options?: HoneycombOptions): HoneycombOptions {
       env.HONEYCOMB_ENABLE_LOCAL_VISUALIZATIONS ||
       options?.localVisualizations ||
       false,
+    skipOptionsValidation:
+      env.HONEYCOMB_SKIP_OPTIONS_VALIDATION ||
+      options?.skipOptionsValidation ||
+      false,
   };
+
+  // skip options validation if requested
+  if (opts.skipOptionsValidation) {
+    return opts;
+  }
 
   // warn if api key is missing
   if (!opts.apiKey) {
@@ -153,6 +168,7 @@ export type HoneycombEnvironmentOptions = {
   SAMPLE_RATE?: number;
   DEBUG?: boolean;
   HONEYCOMB_ENABLE_LOCAL_VISUALIZATIONS?: boolean;
+  HONEYCOMB_SKIP_OPTIONS_VALIDATION?: boolean;
 
   OTEL_SERVICE_NAME?: string;
   OTEL_EXPORTER_OTLP_PROTOCOL?: OtlpProtocol;
@@ -182,6 +198,9 @@ export const getHoneycombEnv = (): HoneycombEnvironmentOptions => {
     DEBUG: parseBoolean(process.env.DEBUG),
     HONEYCOMB_ENABLE_LOCAL_VISUALIZATIONS: parseBoolean(
       process.env.HONEYCOMB_ENABLE_LOCAL_VISUALIZATIONS,
+    ),
+    HONEYCOMB_SKIP_OPTIONS_VALIDATION: parseBoolean(
+      process.env.HONEYCOMB_SKIP_OPTIONS_VALIDATION,
     ),
 
     OTEL_SERVICE_NAME: process.env.OTEL_SERVICE_NAME,

--- a/src/honeycomb-options.ts
+++ b/src/honeycomb-options.ts
@@ -20,6 +20,8 @@ export const MISSING_DATASET_ERROR =
   'WARN: Missing dataset. Specify either HONEYCOMB_DATASET environment variable or dataset in the options parameter.';
 export const MISSING_SERVICE_NAME_ERROR =
   'WARN: Missing service name. Specify either OTEL_SERVICE_NAME environment variable or serviceName in the options parameter.  If left unset, this will show up in Honeycomb as unknown_service:node';
+export const SKIPPING_OPTIONS_VALIDATION_MSG =
+  'DEBUG: Skipping options validation. To re-enable, set skipOptionsValidation option or HONEYCOMB_SKIP_OPTIONS_VALIDATION to false.';
 
 /**
  * The options used to configure the Honeycomb Node SDK.
@@ -117,6 +119,9 @@ export function computeOptions(options?: HoneycombOptions): HoneycombOptions {
 
   // skip options validation if requested
   if (opts.skipOptionsValidation) {
+    if (opts.debug) {
+      console.debug(SKIPPING_OPTIONS_VALIDATION_MSG);
+    }
     return opts;
   }
 

--- a/test/honeycomb-options.test.ts
+++ b/test/honeycomb-options.test.ts
@@ -51,7 +51,7 @@ describe('missing option warnings', () => {
     });
     it('does not warn if api key is missing wehen ignore warnings is true', () => {
       computeOptions({ skipOptionsValidation: true });
-      expect(consoleSpy).toHaveBeenCalledWith(MISSING_API_KEY_ERROR);
+      expect(consoleSpy).not.toHaveBeenCalledWith(MISSING_API_KEY_ERROR);
     });
   });
   describe('service name', () => {
@@ -65,7 +65,7 @@ describe('missing option warnings', () => {
     });
     it('does not warn on missing service name when ignore warnings is true', () => {
       computeOptions({ skipOptionsValidation: true });
-      expect(consoleSpy).toHaveBeenCalledWith(MISSING_SERVICE_NAME_ERROR);
+      expect(consoleSpy).not.toHaveBeenCalledWith(MISSING_SERVICE_NAME_ERROR);
     });
   });
 

--- a/test/honeycomb-options.test.ts
+++ b/test/honeycomb-options.test.ts
@@ -49,6 +49,10 @@ describe('missing option warnings', () => {
       computeOptions({ apiKey: 'test-key' });
       expect(consoleSpy).not.toHaveBeenCalledWith(MISSING_API_KEY_ERROR);
     });
+    it('does not warn if api key is missing wehen ignore warnings is true', () => {
+      computeOptions({ skipOptionsValidation: true });
+      expect(consoleSpy).toHaveBeenCalledWith(MISSING_API_KEY_ERROR);
+    });
   });
   describe('service name', () => {
     it('warns on missing service name', () => {
@@ -58,6 +62,10 @@ describe('missing option warnings', () => {
     it('does not warn if service name is present', () => {
       computeOptions({ serviceName: 'heeeeey' });
       expect(consoleSpy).not.toHaveBeenCalledWith(MISSING_SERVICE_NAME_ERROR);
+    });
+    it('does not warn on missing service name when ignore warnings is true', () => {
+      computeOptions({ skipOptionsValidation: true });
+      expect(consoleSpy).toHaveBeenCalledWith(MISSING_SERVICE_NAME_ERROR);
     });
   });
 

--- a/test/honeycomb-options.test.ts
+++ b/test/honeycomb-options.test.ts
@@ -92,6 +92,13 @@ describe('missing option warnings', () => {
         });
         expect(consoleSpy).toHaveBeenCalledWith(MISSING_DATASET_ERROR);
       });
+      it('does not warn if dataset is missing and skip validation is true', () => {
+        computeOptions({
+          apiKey: classicApiKey,
+          skipOptionsValidation: true,
+        });
+        expect(consoleSpy).not.toHaveBeenCalledWith(MISSING_DATASET_ERROR);
+      });
     });
     describe('environment key', () => {
       it('does not warn on missing dataset', () => {
@@ -106,6 +113,14 @@ describe('missing option warnings', () => {
           dataset: 'unnecessary dataset',
         });
         expect(consoleSpy).toHaveBeenCalledWith(IGNORED_DATASET_ERROR);
+      });
+      it('does not warn if dataset is present and skip validation is tre', () => {
+        computeOptions({
+          apiKey: apiKey,
+          dataset: 'unnecessary dataset',
+          skipOptionsValidation: true,
+        });
+        expect(consoleSpy).not.toHaveBeenCalledWith(MISSING_DATASET_ERROR);
       });
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

Adds a new option to allow skipping options validation. This is useful when the SDK is being used along with an OpenTelemetry Collector which configures API keys.

- Closes #201

## Short description of the changes
- Add new skipOptionsValidation option, includes looking for new `HONEYCOMB_SKIP_OPTIONS_VALIDATION` env var -- default is `false`
- Add test to verify API key and dataset warnings are not seen when new option is set
- A debug message is logged if skip validation is true and debug is true
