### PR TITLE
fix: allow overriding node sdk properties

### DIFF
--- a/src/opentelemetry-node.ts
+++ b/src/opentelemetry-node.ts
@@ -16,12 +16,11 @@ export class HoneycombSDK extends NodeSDK {
   constructor(options?: HoneycombOptions) {
     const opts = computeOptions(options);
     super({
-      ...opts,
-      serviceName: opts?.serviceName,
       resource: configureHoneycombResource(opts),
       metricReader: getHoneycombMetricReader(opts),
       spanProcessor: configureBatchWithBaggageSpanProcessor(opts),
       sampler: configureDeterministicSampler(opts?.sampleRate),
+      ...opts,
     });
 
     if (opts.debug) {

--- a/test/opentelemetry-node.test.ts
+++ b/test/opentelemetry-node.test.ts
@@ -1,18 +1,61 @@
 import { HoneycombSDK } from '../src/opentelemetry-node';
-import { NodeSDK } from '@opentelemetry/sdk-node';
+import { NodeSDK, NodeSDKConfiguration } from '@opentelemetry/sdk-node';
 import { diag } from '@opentelemetry/api';
+import { AlwaysOnSampler } from '@opentelemetry/sdk-trace-base';
+
+jest.mock('@opentelemetry/sdk-node', () => {
+  return {
+    NodeSDK: jest.fn().mockImplementation(),
+  };
+});
+
+const mockedNodeSDK = <jest.Mock<NodeSDK>>NodeSDK;
 
 beforeEach(() => {
   // enable fake timers so timeouts work more relieably. This is required
   // to stop import errors from otlp-grpc-trace-base originating from onInit
   // https://jestjs.io/docs/timer-mocks#enable-fake-timers
   jest.useFakeTimers();
+  mockedNodeSDK.mockClear();
+});
+
+afterAll(() => {
+  mockedNodeSDK.mockRestore();
 });
 
 test('it should return a NodeSDK', () => {
   const honeycomb = new HoneycombSDK();
 
   expect(honeycomb).toBeInstanceOf(NodeSDK);
+});
+
+describe('NodeSDK options', () => {
+  test('it should setup the default sampler', () => {
+    new HoneycombSDK();
+    expect(mockedNodeSDK).toHaveBeenCalledTimes(1);
+    const options = mockedNodeSDK.mock.calls[0][0] as NodeSDKConfiguration;
+    expect(options.sampler.toString()).toBe(
+      'DeterministicSampler(AlwaysOnSampler)',
+    );
+  });
+
+  test('it should allow overriding the default sampler', () => {
+    new HoneycombSDK({
+      sampler: new AlwaysOnSampler(),
+    });
+    expect(mockedNodeSDK).toHaveBeenCalledTimes(1);
+    const options = mockedNodeSDK.mock.calls[0][0] as NodeSDKConfiguration;
+    expect(options.sampler.toString()).toBe('AlwaysOnSampler');
+  });
+
+  test('serviceName is set', () => {
+    new HoneycombSDK({
+      serviceName: 'some-name',
+    });
+    expect(mockedNodeSDK).toHaveBeenCalledTimes(1);
+    const options = mockedNodeSDK.mock.calls[0][0] as NodeSDKConfiguration;
+    expect(options.serviceName).toBe('some-name');
+  });
 });
 
 describe('debugging', () => {


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #203

## Short description of the changes

Allow users of `HoneycombSDK` to override the `NodeSDK` properties such as the `sampler`.

## How to verify that this has the expected result

Pass in a `sampler` to the HoneycomSDK constructor and see it being used instead of the default `DeterministicSampler`.
