### PR TITLE
feat(sampler): add support for parent based sampling

### DIFF
--- a/src/deterministic-sampler.ts
+++ b/src/deterministic-sampler.ts
@@ -5,13 +5,16 @@ import {
   Sampler,
   SamplingResult,
   TraceIdRatioBasedSampler,
+  ParentBasedSampler,
 } from '@opentelemetry/sdk-trace-base';
 import { DEFAULT_SAMPLE_RATE } from './honeycomb-options';
 
 export function configureDeterministicSampler(sampleRate?: number) {
-  return new DeterministicSampler(
-    sampleRate === undefined ? DEFAULT_SAMPLE_RATE : sampleRate,
-  );
+  return new ParentBasedSampler({
+    root: new DeterministicSampler(
+      sampleRate === undefined ? DEFAULT_SAMPLE_RATE : sampleRate,
+    ),
+  });
 }
 
 export class DeterministicSampler implements Sampler {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #203

## Short description of the changes

This is an alternative approach to solve #203 and to #204 where the default `DeterministicSampler` is wrapped in a `ParentBasedSampler` so that out of the box, the default sampler becomes aware of the parent span context state when initialising the library.

Unsure if this might have some unintended consequences so definitely understand if you're not open to this. Feel free to close the PR if so 👍 

## How to verify that this has the expected result
