### PR TITLE
fix: add @opentelemetry/core as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.7.3",
         "@opentelemetry/api": "^1.4.1",
+        "@opentelemetry/core": "^1.13.0",
         "@opentelemetry/exporter-metrics-otlp-grpc": "^0.39.1",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.39.1",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.41.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.7.3",
     "@opentelemetry/api": "^1.4.1",
+    "@opentelemetry/core": "^1.13.0",
     "@opentelemetry/exporter-metrics-otlp-grpc": "^0.39.1",
     "@opentelemetry/exporter-metrics-otlp-proto": "^0.39.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.41.0",


### PR DESCRIPTION
## Which problem is this PR solving?
We need to add `@opentelemetry/core` as a dependency because we are importing an interface and constant directly from it. I looked into whether these values are re-exported from the trace sdk or api packages and that doesn't seem to be the case. I think its okay for this package to depend on `@opentelemetry/core`, other exporter packages have to depend on it as well.

- Closes #206 

## Short description of the changes
- Added `@opentelemetry/core` to `package.json` as a core dependency.

## How to verify that this has the expected result
- `@opentelemetry/core` is listed is a direct dependency in `package-lock.json`
- Existing tests pass
- Install works on versions of yarn and pnpm
