### PR TITLE
maint: add custom sampler warning

### DIFF
--- a/src/honeycomb-options.ts
+++ b/src/honeycomb-options.ts
@@ -22,7 +22,8 @@ export const MISSING_SERVICE_NAME_ERROR =
   'WARN: Missing service name. Specify either OTEL_SERVICE_NAME environment variable or serviceName in the options parameter.  If left unset, this will show up in Honeycomb as unknown_service:node';
 export const SKIPPING_OPTIONS_VALIDATION_MSG =
   'DEBUG: Skipping options validation. To re-enable, set skipOptionsValidation option or HONEYCOMB_SKIP_OPTIONS_VALIDATION to false.';
-
+export const SAMPLER_OVERRIDE_WARNING =
+  'WARN: Default deterministic sampler has been overridden. Make sure the sampleRate option is set and matches the sampleRate of  the custom sampler. Non-deterministic sampleRate could lead to missing spans in Honeycomb.';
 /**
  * The options used to configure the Honeycomb Node SDK.
  */
@@ -143,6 +144,11 @@ export function computeOptions(options?: HoneycombOptions): HoneycombOptions {
   // warn if dataset is missing if using classic key
   if (opts.apiKey && isClassic(opts.apiKey) && !opts.dataset) {
     console.warn(MISSING_DATASET_ERROR);
+  }
+
+  // warn if custom sampler provided
+  if (opts.sampler) {
+    console.warn(SAMPLER_OVERRIDE_WARNING);
   }
 
   return opts;

--- a/src/honeycomb-options.ts
+++ b/src/honeycomb-options.ts
@@ -23,7 +23,7 @@ export const MISSING_SERVICE_NAME_ERROR =
 export const SKIPPING_OPTIONS_VALIDATION_MSG =
   'DEBUG: Skipping options validation. To re-enable, set skipOptionsValidation option or HONEYCOMB_SKIP_OPTIONS_VALIDATION to false.';
 export const SAMPLER_OVERRIDE_WARNING =
-  'WARN: Default deterministic sampler has been overridden. Honeycomb requires a resource attribute called SampleRate to properly show weighted values. Non-deterministic sampleRate could lead to missing spans in Honeycomb. See our docs for more details.';
+  'WARN: Default deterministic sampler has been overridden. Honeycomb requires a resource attribute called SampleRate to properly show weighted values. Non-deterministic sampleRate could lead to missing spans in Honeycomb. See our docs for more details. https://docs.honeycomb.io/getting-data-in/opentelemetry/node-distro/#sampling-without-the-honeycomb-sdk';
 /**
  * The options used to configure the Honeycomb Node SDK.
  */

--- a/src/honeycomb-options.ts
+++ b/src/honeycomb-options.ts
@@ -23,7 +23,7 @@ export const MISSING_SERVICE_NAME_ERROR =
 export const SKIPPING_OPTIONS_VALIDATION_MSG =
   'DEBUG: Skipping options validation. To re-enable, set skipOptionsValidation option or HONEYCOMB_SKIP_OPTIONS_VALIDATION to false.';
 export const SAMPLER_OVERRIDE_WARNING =
-  'WARN: Default deterministic sampler has been overridden. Make sure the sampleRate option is set and matches the sampleRate of  the custom sampler. Non-deterministic sampleRate could lead to missing spans in Honeycomb.';
+  'WARN: Default deterministic sampler has been overridden. Honeycomb requires a resource attribute called SampleRate to properly show weighted values. Non-deterministic sampleRate could lead to missing spans in Honeycomb. See our docs for more details.';
 /**
  * The options used to configure the Honeycomb Node SDK.
  */

--- a/test/honeycomb-options.test.ts
+++ b/test/honeycomb-options.test.ts
@@ -11,7 +11,9 @@ import {
   MISSING_DATASET_ERROR,
   MISSING_SERVICE_NAME_ERROR,
   OtlpProtocolKind,
+  SAMPLER_OVERRIDE_WARNING,
 } from '../src/honeycomb-options';
+import { AlwaysOnSampler } from '@opentelemetry/sdk-trace-base';
 
 // classic keys are 32 chars long
 const classicApiKey = 'this is a string that is 32 char';
@@ -27,7 +29,7 @@ test('it should have an apiKey property on the HoneycombOptions object', () => {
   expect(testApiKey).toEqual(true);
 });
 
-describe('missing option warnings', () => {
+describe('options warnings', () => {
   const consoleSpy = jest
     .spyOn(console, 'warn')
     .mockImplementation(() => undefined);
@@ -122,6 +124,20 @@ describe('missing option warnings', () => {
         });
         expect(consoleSpy).not.toHaveBeenCalledWith(MISSING_DATASET_ERROR);
       });
+    });
+  });
+
+  describe('custom sampler', () => {
+    it('warns if a custom sampler is provided', () => {
+      const customSampler = new AlwaysOnSampler();
+      computeOptions({
+        sampler: customSampler,
+      });
+      expect(consoleSpy).toHaveBeenCalledWith(SAMPLER_OVERRIDE_WARNING);
+    });
+    it('does not warn if the default sampler is being used', () => {
+      computeOptions({});
+      expect(consoleSpy).not.toHaveBeenCalledWith(SAMPLER_OVERRIDE_WARNING);
     });
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
Adds a warning if a custom sampler is provided. There are some pitfalls with providing a custom sampler if the `sampleRate` is non-deterministic.

## Short description of the changes
- Added a warning if `sampler` option is provided by the user

## How to verify that this has the expected result
- Unit tests pass 
- Test it out by adding a custom sampler to the `sampler` property in a test app.
