### PR TITLE
maint: add dependabot groups and example deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,43 @@ updates:
     commit-message:
       prefix: "maint"
       include: "scope"
+    groups:
+      otel:
+        patterns:
+          - "@opentelemetry/*"
+
+  - package-ecosystem: "npm"
+    directory: "/examples/hello-node"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "type: dependencies"
+    reviewers:
+      - "honeycombio/telemetry-team"
+    commit-message:
+      prefix: "maint"
+      include: "scope"
+
+  - package-ecosystem: "npm"
+    directory: "/examples/hello-node-express"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "type: dependencies"
+    reviewers:
+      - "honeycombio/telemetry-team"
+    commit-message:
+      prefix: "maint"
+      include: "scope"
+
+  - package-ecosystem: "npm"
+    directory: "/examples/hello-node-express-ts"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "type: dependencies"
+    reviewers:
+      - "honeycombio/telemetry-team"
+    commit-message:
+      prefix: "maint"
+      include: "scope"


### PR DESCRIPTION
## Which problem is this PR solving?

- otel dependencies should generally be updated together
- examples are not kept up to date with dependabot

## Short description of the changes

- add dependabot grouping for `"@opentelemetry/*"`
- add dependabot for example directories

## How to verify that this has the expected result

Dependabot should group PRs for OTel and should also open PRs for example apps. I considered some grouping in the example apps but those are smaller and primarily rely on the main package. Also the two different `"@opentelemetry/*"` packages are from two different repos (core and contrib) so they'll get released at different times.