### PR TITLE
maint: more batching of dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,14 @@ updates:
       otel:
         patterns:
           - "@opentelemetry/*"
-
+      dev-dependencies:
+        patterns:
+          - "@type*"
+          - "eslint*"
+          - "jest*"
+          - "prettier"
+          - "ts-*"
+          - "typescript"
   - package-ecosystem: "npm"
     directory: "/examples/hello-node"
     schedule:
@@ -32,6 +39,10 @@ updates:
     commit-message:
       prefix: "maint"
       include: "scope"
+    groups:
+      examples:
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/examples/hello-node-express"
@@ -44,6 +55,10 @@ updates:
     commit-message:
       prefix: "maint"
       include: "scope"
+    groups:
+      examples:
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/examples/hello-node-express-ts"
@@ -56,3 +71,7 @@ updates:
     commit-message:
       prefix: "maint"
       include: "scope"
+    groups:
+      examples:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Which problem is this PR solving?

- lots of dependabots still

## Short description of the changes

- group all example directory dependencies into one PR where possible (unfortunately they still have to be a PR per directory, unless we remove the package.json for each example and just use a shared one... which is an option 🤔 )
- group all dev dependencies into one PR

## How to verify that this has the expected result

once this merges and dependabot checks for updates, the 4 open dev-dependency PRs should close and reopen in one PR
