### PR TITLE
fix: ease restriction on api version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.3",
-        "@opentelemetry/api": "~1.8.0",
+        "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/core": "~1.22.0",
         "@opentelemetry/exporter-metrics-otlp-grpc": "~0.49.1",
         "@opentelemetry/exporter-metrics-otlp-proto": "~0.49.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.3",
-    "@opentelemetry/api": "~1.8.0",
+    "@opentelemetry/api": "^1.8.0",
     "@opentelemetry/core": "~1.22.0",
     "@opentelemetry/exporter-metrics-otlp-grpc": "~0.49.1",
     "@opentelemetry/exporter-metrics-otlp-proto": "~0.49.1",


### PR DESCRIPTION
## Which problem is this PR solving?

- Follow-up from https://github.com/honeycombio/honeycomb-opentelemetry-node/issues/293#issuecomment-2002328040

## Short description of the changes

- Use caret for versioning on API dependency, allowing for newer minor versions

## How to verify that this has the expected result

Using this package `@honeycombio/opentelemetry-node` with upstream packages should have minimal version conflicts. The more restrictive version ranges (tilde instead of caret) were initially set because of breaking changes across different packages that affected end users, and the hope with the change was to minimize incompatibilities. However, the API range may have been too restrictive - perhaps we can adjust this and see if we need to ease up on others as well?