### PR TITLE
chore: update team for dependabot review

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     labels:
       - "type: dependencies"
     reviewers:
-      - "honeycombio/telemetry-team"
+      - "honeycombio/pipeline-team"
     commit-message:
       prefix: "maint"
       include: "scope"
@@ -35,7 +35,7 @@ updates:
     labels:
       - "type: dependencies"
     reviewers:
-      - "honeycombio/telemetry-team"
+      - "honeycombio/pipeline-team"
     commit-message:
       prefix: "maint"
       include: "scope"
@@ -51,7 +51,7 @@ updates:
     labels:
       - "type: dependencies"
     reviewers:
-      - "honeycombio/telemetry-team"
+      - "honeycombio/pipeline-team"
     commit-message:
       prefix: "maint"
       include: "scope"
@@ -67,7 +67,7 @@ updates:
     labels:
       - "type: dependencies"
     reviewers:
-      - "honeycombio/telemetry-team"
+      - "honeycombio/pipeline-team"
     commit-message:
       prefix: "maint"
       include: "scope"


### PR DESCRIPTION
## Which problem is this PR solving?

- dependabot had wrong (old) team for reviewers

## Short description of the changes

- updated dependabot file to set pipeline-team as reviewers

## How to verify that this has the expected result

new dependabot PRs should properly assign pipeline team as reviewers